### PR TITLE
ベット額によってスコア補正と崩壊確率補正を変更

### DIFF
--- a/Assets/ScriptableObjects/AllCardData.asset
+++ b/Assets/ScriptableObjects/AllCardData.asset
@@ -14,17 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cardList:
   - {fileID: 11400000, guid: 5ecb5aa2c56fa41448a2e55ccf2af044, type: 2}
-  - {fileID: 11400000, guid: 16f56a4b6822e49e4917ff50562bcb0c, type: 2}
-  - {fileID: 11400000, guid: 42527f7f2139246168146f74f60d2828, type: 2}
+  - {fileID: 11400000, guid: 49cdb945655a048a09f967ca7e3420b9, type: 2}
+  - {fileID: 11400000, guid: 641f6d282ae7d4396ae3360b1d8eeaf1, type: 2}
+  - {fileID: 11400000, guid: 7ad383a5532d94c388d7b947a6c5757e, type: 2}
   - {fileID: 11400000, guid: eee7d85232db54b5d9d38d1094a65137, type: 2}
   - {fileID: 11400000, guid: aa7a92a9d71844acda9e037d9dfe4fd3, type: 2}
+  - {fileID: 11400000, guid: 16f56a4b6822e49e4917ff50562bcb0c, type: 2}
+  - {fileID: 11400000, guid: 340062878b38c4d26abf33d3bf2cc4d3, type: 2}
+  - {fileID: 11400000, guid: 96418a77f5ef94e20bf72ebde966a197, type: 2}
   - {fileID: 11400000, guid: 7837cafdc41164c51b9798d876501fcb, type: 2}
-  - {fileID: 11400000, guid: 3002b2ee333b642a9891d72701ba3081, type: 2}
-  - {fileID: 11400000, guid: 157a65776e6264dbf8f91dec42242cbe, type: 2}
   - {fileID: 11400000, guid: e0fc958e1d16741e6a114ae6fbc556ba, type: 2}
   - {fileID: 11400000, guid: 73cde9b6853394361a93499ee00e9474, type: 2}
-  - {fileID: 11400000, guid: 7ad383a5532d94c388d7b947a6c5757e, type: 2}
-  - {fileID: 11400000, guid: 641f6d282ae7d4396ae3360b1d8eeaf1, type: 2}
-  - {fileID: 11400000, guid: 340062878b38c4d26abf33d3bf2cc4d3, type: 2}
-  - {fileID: 11400000, guid: 49cdb945655a048a09f967ca7e3420b9, type: 2}
-  - {fileID: 11400000, guid: 96418a77f5ef94e20bf72ebde966a197, type: 2}
+  - {fileID: 11400000, guid: 3002b2ee333b642a9891d72701ba3081, type: 2}
+  - {fileID: 11400000, guid: 157a65776e6264dbf8f91dec42242cbe, type: 2}
+  - {fileID: 11400000, guid: 42527f7f2139246168146f74f60d2828, type: 2}

--- a/Assets/Scripts/Game/Logic/CollapseJudge.cs
+++ b/Assets/Scripts/Game/Logic/CollapseJudge.cs
@@ -7,6 +7,23 @@ using UnityEngine;
 public static class CollapseJudge
 {
     /// <summary>
+    /// ベット額による崩壊確率補正倍率を取得
+    /// </summary>
+    /// <param name="mentalBet">精神ベット値</param>
+    /// <returns>崩壊確率補正倍率</returns>
+    private static float GetBetCollapseMultiplier(int mentalBet)
+    {
+        return mentalBet switch
+        {
+            >= 1 and <= 5 => 0.8f,
+            >= 6 and <= 10 => 1.0f,
+            >= 11 and <= 15 => 1.4f,
+            >= 16 and <= 20 => 1.8f,
+            _ => 1.0f // デフォルト値
+        };
+    }
+
+    /// <summary>
     /// カードの崩壊確率を計算
     /// </summary>
     /// <param name="move">プレイヤーの手</param>
@@ -14,17 +31,20 @@ public static class CollapseJudge
     private static float CalculateCollapseChance(PlayerMove move)
     {
         if (move == null || !move.SelectedCard) return 0f;
-        
+
         var threshold = move.SelectedCard.CollapseThreshold;
         if (move.MentalBet < threshold) return 0f; // 閾値未満では崩壊しない
-        
+
         // 基本崩壊確率を計算
         var baseChance = (move.MentalBet - threshold) * 0.2f;
-        
+
         // プレイスタイルによる倍率を適用
         var playStyleMultiplier = move.PlayStyle.GetCollapseMultiplier();
-        
-        return baseChance * playStyleMultiplier;
+
+        // ベット額による崩壊確率補正倍率を取得
+        var betCollapseMultiplier = GetBetCollapseMultiplier(move.MentalBet);
+
+        return baseChance * playStyleMultiplier * betCollapseMultiplier;
     }
     
     /// <summary>

--- a/Assets/Scripts/Game/Logic/ScoreCalculator.cs
+++ b/Assets/Scripts/Game/Logic/ScoreCalculator.cs
@@ -7,6 +7,23 @@ using UnityEngine;
 public static class ScoreCalculator
 {
     /// <summary>
+    /// ベット額によるスコア補正倍率を取得
+    /// </summary>
+    /// <param name="mentalBet">精神ベット値</param>
+    /// <returns>スコア補正倍率</returns>
+    private static float GetBetScoreMultiplier(int mentalBet)
+    {
+        return mentalBet switch
+        {
+            >= 1 and <= 5 => 0.8f,
+            >= 6 and <= 10 => 1.0f,
+            >= 11 and <= 15 => 1.3f,
+            >= 16 and <= 20 => 1.6f,
+            _ => 1.0f // デフォルト値
+        };
+    }
+
+    /// <summary>
     /// プレイヤーの手のスコアを計算
     /// </summary>
     /// <param name="move">プレイヤーの手（カード選択、プレイスタイル、精神ベット）</param>
@@ -15,14 +32,17 @@ public static class ScoreCalculator
     public static float CalculateScore(PlayerMove move, ThemeData theme)
     {
         if (move == null || !theme) return 0f;
-        
+
         // テーマから該当属性の倍率を取得
         var attributeMultiplier = theme.GetMultiplier(move.SelectedCard.Attribute);
-        
+
         // プレイスタイルによるスコア倍率を取得
         var playStyleMultiplier = move.PlayStyle.GetScoreMultiplier();
-        
-        // スコア = 属性倍率 × 精神ベット × カード固有の倍率 × プレイスタイル倍率
-        return attributeMultiplier * move.MentalBet * move.SelectedCard.ScoreMultiplier * playStyleMultiplier;
+
+        // ベット額によるスコア補正倍率を取得
+        var betScoreMultiplier = GetBetScoreMultiplier(move.MentalBet);
+
+        // スコア = 属性倍率 × 精神ベット × カード固有の倍率 × プレイスタイル倍率 × ベット補正倍率
+        return attributeMultiplier * move.MentalBet * move.SelectedCard.ScoreMultiplier * playStyleMultiplier * betScoreMultiplier;
     }
 }


### PR DESCRIPTION
## 実装内容
- 精神ベット額によるスコア＆崩壊確率の補正倍率を設定
- スコア計算式に補正倍率を追加
- カードの崩壊確率計算式に補正倍率を追加