### PR TITLE
引き分け時、勝敗をランダム変更

### DIFF
--- a/Assets/ScriptableObjects/AllCardData.asset
+++ b/Assets/ScriptableObjects/AllCardData.asset
@@ -14,17 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cardList:
   - {fileID: 11400000, guid: 5ecb5aa2c56fa41448a2e55ccf2af044, type: 2}
-  - {fileID: 11400000, guid: 16f56a4b6822e49e4917ff50562bcb0c, type: 2}
-  - {fileID: 11400000, guid: 42527f7f2139246168146f74f60d2828, type: 2}
+  - {fileID: 11400000, guid: 49cdb945655a048a09f967ca7e3420b9, type: 2}
+  - {fileID: 11400000, guid: 641f6d282ae7d4396ae3360b1d8eeaf1, type: 2}
+  - {fileID: 11400000, guid: 7ad383a5532d94c388d7b947a6c5757e, type: 2}
   - {fileID: 11400000, guid: eee7d85232db54b5d9d38d1094a65137, type: 2}
   - {fileID: 11400000, guid: aa7a92a9d71844acda9e037d9dfe4fd3, type: 2}
+  - {fileID: 11400000, guid: 16f56a4b6822e49e4917ff50562bcb0c, type: 2}
+  - {fileID: 11400000, guid: 340062878b38c4d26abf33d3bf2cc4d3, type: 2}
+  - {fileID: 11400000, guid: 96418a77f5ef94e20bf72ebde966a197, type: 2}
   - {fileID: 11400000, guid: 7837cafdc41164c51b9798d876501fcb, type: 2}
-  - {fileID: 11400000, guid: 3002b2ee333b642a9891d72701ba3081, type: 2}
-  - {fileID: 11400000, guid: 157a65776e6264dbf8f91dec42242cbe, type: 2}
   - {fileID: 11400000, guid: e0fc958e1d16741e6a114ae6fbc556ba, type: 2}
   - {fileID: 11400000, guid: 73cde9b6853394361a93499ee00e9474, type: 2}
-  - {fileID: 11400000, guid: 7ad383a5532d94c388d7b947a6c5757e, type: 2}
-  - {fileID: 11400000, guid: 641f6d282ae7d4396ae3360b1d8eeaf1, type: 2}
-  - {fileID: 11400000, guid: 340062878b38c4d26abf33d3bf2cc4d3, type: 2}
-  - {fileID: 11400000, guid: 49cdb945655a048a09f967ca7e3420b9, type: 2}
-  - {fileID: 11400000, guid: 96418a77f5ef94e20bf72ebde966a197, type: 2}
+  - {fileID: 11400000, guid: 3002b2ee333b642a9891d72701ba3081, type: 2}
+  - {fileID: 11400000, guid: 157a65776e6264dbf8f91dec42242cbe, type: 2}
+  - {fileID: 11400000, guid: 42527f7f2139246168146f74f60d2828, type: 2}

--- a/Assets/Scripts/Game/Logic/GameManager.cs
+++ b/Assets/Scripts/Game/Logic/GameManager.cs
@@ -384,8 +384,9 @@ public class GameManager: IStartable, IDisposable
 
         if (_playerCollapse && _npcCollapse)
         {
-            result = "引き分け（両者カード崩壊）";
-            playerWon = false; // 引き分けとして扱う
+            // ランダムで勝敗を決定
+            playerWon = UnityEngine.Random.Range(0, 2) == 0;
+            result = playerWon ? "あなたの勝利\n（引き分け→ランダム決着）" : "相手の勝利\n（引き分け→ランダム決着）";
         }
         else if (_playerCollapse)
         {
@@ -412,8 +413,9 @@ public class GameManager: IStartable, IDisposable
             }
             else
             {
-                result = "引き分け";
-                playerWon = false; // 引き分けとして扱う
+                // スコア引き分けもランダム決着
+                playerWon = UnityEngine.Random.Range(0, 2) == 0;
+                result = playerWon ? "あなたの勝利\n（引き分け→ランダム決着）" : "相手の勝利\n（引き分け→ランダム決着）";
             }
         }
         
@@ -438,19 +440,13 @@ public class GameManager: IStartable, IDisposable
         
         await _uiPresenter.HideBlackOverlay();
 
-        // 引き分けでない場合、勝利数を更新してバトル終了チェック
-        // 崩壊による引き分けも考慮
-        var isDrawByCollapse = _playerCollapse && _npcCollapse;
-        var isScoreTie = Mathf.Approximately(playerScore, npcScore);
-        if (!isDrawByCollapse && !isScoreTie)
+        // すべての場合で勝利数をカウントするように変更
+        if (UpdateWinsAndCheckBattleEnd(playerWon))
         {
-            if (UpdateWinsAndCheckBattleEnd(playerWon))
-            {
-                // 3勝に達した場合、カード処理をスキップしてバトル終了へ
-                _isProcessing = false;
-                ChangeState(GameState.BattleEnd);
-                return;
-            }
+            // 3勝に達した場合、カード処理をスキップしてバトル終了へ
+            _isProcessing = false;
+            ChangeState(GameState.BattleEnd);
+            return;
         }
         
         // 使用したカードをプレイ


### PR DESCRIPTION
## 実装内容
- 以下の場合に勝敗をランダムに変更  
➡両者のスコアが同じ時。  
➡両者のカード崩壊時。  
- すべての場合で勝利数をカウントするように変更