### PR TITLE
カード崩壊崩壊演出をアナウンスと同時にする

### DIFF
--- a/Assets/ScriptableObjects/AllCardData.asset
+++ b/Assets/ScriptableObjects/AllCardData.asset
@@ -14,17 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cardList:
   - {fileID: 11400000, guid: 5ecb5aa2c56fa41448a2e55ccf2af044, type: 2}
-  - {fileID: 11400000, guid: 16f56a4b6822e49e4917ff50562bcb0c, type: 2}
-  - {fileID: 11400000, guid: 42527f7f2139246168146f74f60d2828, type: 2}
+  - {fileID: 11400000, guid: 49cdb945655a048a09f967ca7e3420b9, type: 2}
+  - {fileID: 11400000, guid: 641f6d282ae7d4396ae3360b1d8eeaf1, type: 2}
+  - {fileID: 11400000, guid: 7ad383a5532d94c388d7b947a6c5757e, type: 2}
   - {fileID: 11400000, guid: eee7d85232db54b5d9d38d1094a65137, type: 2}
   - {fileID: 11400000, guid: aa7a92a9d71844acda9e037d9dfe4fd3, type: 2}
+  - {fileID: 11400000, guid: 16f56a4b6822e49e4917ff50562bcb0c, type: 2}
+  - {fileID: 11400000, guid: 340062878b38c4d26abf33d3bf2cc4d3, type: 2}
+  - {fileID: 11400000, guid: 96418a77f5ef94e20bf72ebde966a197, type: 2}
   - {fileID: 11400000, guid: 7837cafdc41164c51b9798d876501fcb, type: 2}
-  - {fileID: 11400000, guid: 3002b2ee333b642a9891d72701ba3081, type: 2}
-  - {fileID: 11400000, guid: 157a65776e6264dbf8f91dec42242cbe, type: 2}
   - {fileID: 11400000, guid: e0fc958e1d16741e6a114ae6fbc556ba, type: 2}
   - {fileID: 11400000, guid: 73cde9b6853394361a93499ee00e9474, type: 2}
-  - {fileID: 11400000, guid: 7ad383a5532d94c388d7b947a6c5757e, type: 2}
-  - {fileID: 11400000, guid: 641f6d282ae7d4396ae3360b1d8eeaf1, type: 2}
-  - {fileID: 11400000, guid: 340062878b38c4d26abf33d3bf2cc4d3, type: 2}
-  - {fileID: 11400000, guid: 49cdb945655a048a09f967ca7e3420b9, type: 2}
-  - {fileID: 11400000, guid: 96418a77f5ef94e20bf72ebde966a197, type: 2}
+  - {fileID: 11400000, guid: 3002b2ee333b642a9891d72701ba3081, type: 2}
+  - {fileID: 11400000, guid: 157a65776e6264dbf8f91dec42242cbe, type: 2}
+  - {fileID: 11400000, guid: 42527f7f2139246168146f74f60d2828, type: 2}

--- a/Assets/Scripts/Game/Logic/GameManager.cs
+++ b/Assets/Scripts/Game/Logic/GameManager.cs
@@ -336,7 +336,7 @@ public class GameManager: IStartable, IDisposable
         // カード崩壊判定
         _playerCollapse = CollapseJudge.ShouldCollapse(_playerMove);
         _npcCollapse = CollapseJudge.ShouldCollapse(_npcMove);
-        
+
         // 崩壊結果を表示
         if (_playerCollapse || _npcCollapse)
         {
@@ -347,8 +347,15 @@ public class GameManager: IStartable, IDisposable
                 collapseMessage = "プレイヤーのカードが崩壊した";
             else
                 collapseMessage = "対戦相手のカードが崩壊した";
-                
+
             await _uiPresenter.ShowAnnouncement(collapseMessage, 1.0f);
+            // 崩壊演出を実行
+            //var tasks = new List<UniTask> { _uiPresenter.ShowAnnouncement(collapseMessage, 1.0f) };
+            //if (_playerCollapse) tasks.Add(UniTask.Create(async () => _player.CollapseSelectedCard()));
+            //if (_npcCollapse) tasks.Add(UniTask.Create(async () => _enemy.CollapseSelectedCard()));
+            //await UniTask.WhenAll(tasks);
+            if (_playerCollapse) _player.CollapseSelectedCard();
+            if (_npcCollapse) _enemy.CollapseSelectedCard();
         }
         
         // 結果表示フェーズに移行
@@ -460,7 +467,6 @@ public class GameManager: IStartable, IDisposable
             // 人格ログ: プレイヤーカード崩壊イベント記録
             if (playerCollapseCard)
                 _personalityLogService.LogCardCollapse("player", playerCollapseCard);
-            _player.CollapseSelectedCard();
         }
         else
         {
@@ -496,7 +502,6 @@ public class GameManager: IStartable, IDisposable
             // 人格ログ: NPCカード崩壊イベント記録
             if (npcCollapseCard)
                 _personalityLogService.LogCardCollapse("enemy", npcCollapseCard);
-            _enemy.CollapseSelectedCard();
         }
         else
         {

--- a/Assets/Scripts/Game/Logic/GameManager.cs
+++ b/Assets/Scripts/Game/Logic/GameManager.cs
@@ -350,12 +350,12 @@ public class GameManager: IStartable, IDisposable
 
             await _uiPresenter.ShowAnnouncement(collapseMessage, 1.0f);
             // 崩壊演出を実行
-            //var tasks = new List<UniTask> { _uiPresenter.ShowAnnouncement(collapseMessage, 1.0f) };
-            //if (_playerCollapse) tasks.Add(UniTask.Create(async () => _player.CollapseSelectedCard()));
-            //if (_npcCollapse) tasks.Add(UniTask.Create(async () => _enemy.CollapseSelectedCard()));
-            //await UniTask.WhenAll(tasks);
-            if (_playerCollapse) _player.CollapseSelectedCard();
-            if (_npcCollapse) _enemy.CollapseSelectedCard();
+            var tasks = new List<UniTask> { _uiPresenter.ShowAnnouncement(collapseMessage, 1.0f) };
+
+            if (_playerCollapse) tasks.Add(_player.CollapseSelectedCard());
+            if (_npcCollapse) tasks.Add(_enemy.CollapseSelectedCard());
+
+            await UniTask.WhenAll(tasks);
         }
         
         // 結果表示フェーズに移行

--- a/Assets/Scripts/Game/Logic/GameManager.cs
+++ b/Assets/Scripts/Game/Logic/GameManager.cs
@@ -348,7 +348,6 @@ public class GameManager: IStartable, IDisposable
             else
                 collapseMessage = "対戦相手のカードが崩壊した";
 
-            await _uiPresenter.ShowAnnouncement(collapseMessage, 1.0f);
             // 崩壊演出を実行
             var tasks = new List<UniTask> { _uiPresenter.ShowAnnouncement(collapseMessage, 1.0f) };
 
@@ -397,7 +396,7 @@ public class GameManager: IStartable, IDisposable
         }
         else if (_playerCollapse)
         {
-            result = "対戦の勝利（あなたのカード崩壊）";
+            result = "相手の勝利（あなたのカード崩壊）";
             playerWon = false;
         }
         else if (_npcCollapse)

--- a/Assets/Scripts/Game/Presenters/PlayerPresenter.cs
+++ b/Assets/Scripts/Game/Presenters/PlayerPresenter.cs
@@ -222,7 +222,7 @@ public abstract class PlayerPresenter : IDisposable
     /// <summary>
     /// 選択したカードを崩壊させる（UI制御付き）
     /// </summary>
-    public void CollapseSelectedCard()
+    public async UniTask CollapseSelectedCard()
     {
         var selectedIndex = SelectedIndex.CurrentValue;
         
@@ -232,7 +232,7 @@ public abstract class PlayerPresenter : IDisposable
             // 崩壊アニメーションを再生
             if (selectedIndex >= 0)
             {
-                _handView.PlayCollapseAnimation(selectedIndex).Forget();
+                await _handView.PlayCollapseAnimation(selectedIndex); // awaitで待機
             }
         }
     }


### PR DESCRIPTION
## 実装内容
- カード崩壊演出をアナウンスと同時に
- `CollapseSelectedCard`内部でアニメーションをawaitして、`UniTask`型を返すように変更
