### PR TITLE
Steam deploy を単一ジョブ化し steamcmd で直接配信

### DIFF
--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -9,132 +9,16 @@ permissions:
   contents: read
 
 jobs:
-  generate-version:
-    name: Generate Version 🔢
-    runs-on: [self-hosted, macOS]
-    outputs:
-      version: ${{ steps.version.outputs.buildVersion }}
-    steps:
-      - name: Generate version string 🔢
-        id: version
-        run: |
-          # チェックアウト不要: git ls-remote でタグ一覧のみ取得（オブジェクトをDLしない）
-          BASE_VERSION=$(git ls-remote --tags --sort=-version:refname \
-            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
-            | grep -v '\^{}' | head -n1 | sed 's|.*refs/tags/||')
-          BASE_VERSION="${BASE_VERSION:-0.0.0}"
-          DATE_JST=$(TZ=Asia/Tokyo date '+%Y/%m/%d %H:%M:%S')
-          SHORT_SHA="${GITHUB_SHA:0:7}"
-          FULL_VERSION="${BASE_VERSION} ${DATE_JST} ${SHORT_SHA}"
-          echo "buildVersion=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Generated version: ${FULL_VERSION}"
-
-  build-windows:
-    name: Build Windows 🪟
-    runs-on: [self-hosted, macOS]
-    needs: generate-version
-    steps:
-      - name: Setup Unity project 📥
-        uses: void2610/unity-coding-standards/.github/actions/setup-unity-project@main
-        with:
-          unity-version: 6000.3.10f1
-
-      - name: Fix symlink for my-unity-settings 🔗
-        run: |
-          rm -rf Assets/Scripts/SettingsSystem
-          cp -r my-unity-settings Assets/Scripts/SettingsSystem
-
-      - name: Build Windows project 🏗️
-        env:
-          BUILD_VERSION: ${{ needs.generate-version.outputs.version }}
-        run: |
-          UNITY_PATH="/Applications/Unity/Hub/Editor/6000.3.10f1/Unity.app/Contents/MacOS/Unity"
-          "$UNITY_PATH" \
-            -batchmode \
-            -quit \
-            -nographics \
-            -projectPath "$GITHUB_WORKSPACE" \
-            -buildTarget StandaloneWindows64 \
-            -executeMethod CiBuild.BuildWindows \
-            -logFile -
-
-      - name: Upload Windows build artifact 📤
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-build
-          path: builds/StandaloneWindows64
-          retention-days: 1
-
-  build-mac:
-    name: Build Mac 🍎
-    runs-on: [self-hosted, macOS]
-    needs: generate-version
-    steps:
-      - name: Setup Unity project 📥
-        uses: void2610/unity-coding-standards/.github/actions/setup-unity-project@main
-        with:
-          unity-version: 6000.3.10f1
-
-      - name: Fix symlink for my-unity-settings 🔗
-        run: |
-          rm -rf Assets/Scripts/SettingsSystem
-          cp -r my-unity-settings Assets/Scripts/SettingsSystem
-
-      - name: Build Mac project 🏗️
-        env:
-          BUILD_VERSION: ${{ needs.generate-version.outputs.version }}
-        run: |
-          UNITY_PATH="/Applications/Unity/Hub/Editor/6000.3.10f1/Unity.app/Contents/MacOS/Unity"
-          "$UNITY_PATH" \
-            -batchmode \
-            -quit \
-            -nographics \
-            -projectPath "$GITHUB_WORKSPACE" \
-            -buildTarget StandaloneOSX \
-            -executeMethod CiBuild.BuildMac \
-            -logFile -
-
-      - name: Upload Mac build artifact 📤
-        uses: actions/upload-artifact@v4
-        with:
-          name: mac-build
-          path: builds/StandaloneOSX
-          retention-days: 1
-
-  deploy-steam:
-    name: Deploy to Steam 🚀
-    needs: [build-windows, build-mac]
-    runs-on: [self-hosted, macOS]
-    environment:
-      name: steam-production
-    
-    steps:
-      - name: Download Windows build 📥
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-build
-          path: builds/StandaloneWindows64
-
-      - name: Download Mac build 📥
-        uses: actions/download-artifact@v4
-        with:
-          name: mac-build
-          path: builds/StandaloneOSX
-
-      - name: Get short SHA 🔢
-        id: short_sha
-        run: echo "sha_short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-      
-      - name: Deploy to Steam 🎮
-        id: steam_deploy
-        continue-on-error: true
-        uses: game-ci/steam-deploy@v3
-        with:
-          username: ${{ secrets.STEAM_USERNAME }}
-          configVdf: ${{ secrets.STEAM_CONFIG_VDF }}
-          appId: ${{ secrets.STEAM_APP_ID }}
-          buildDescription: auto deploy via github actions (${{ steps.short_sha.outputs.sha_short }})
-          rootPath: builds
-          depot1Path: StandaloneWindows64
-          depot2Path: StandaloneOSX
-          releaseBranch: test
+  steam-deploy:
+    name: Steam Deploy
+    uses: void2610/unity-coding-standards/.github/workflows/steam-deploy-self-hosted.yml@main
+    with:
+      unity-version: 6000.3.10f1
+      runner-labels: '["self-hosted","macOS"]'
+      windows-execute-method: CiBuild.BuildWindows
+      mac-execute-method: CiBuild.BuildMac
+      release-branch: test
+    secrets:
+      STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+      STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
+      STEAM_APP_ID: ${{ secrets.STEAM_APP_ID }}


### PR DESCRIPTION
## 解決する 2 つの問題

既存の `Steam Deploy 🎮` workflow を調査したところ、以下が判明:

1. **game-ci/steam-deploy@v3 は Docker container action** のため macOS self-hosted ランナーでは `Container action is only supported on Linux` で即エラー。`continue-on-error: true` で隠されていたが **Steam には一度も上がっていなかった**
2. build ジョブ → deploy ジョブの **artifact upload/download に合計 30 分** かかっていた（self-hosted → GitHub Azure Blob → self-hosted の往復）

## アプローチ

- unity-coding-standards に `steamcmd-deploy` composite action を新規追加。macOS 向け steamcmd バイナリを直接実行（depot ID は `appId+1` / `appId+2` の連番前提で VDF を action 内で生成）
- `steam-deploy-self-hosted.yml` を 4 ジョブから **単一ジョブ** に畳み込み。同じ self-hosted ランナー上で `generate-version → build Win → build Mac → steamcmd upload` を順次実行し、artifact を廃止
- 親リポ側は薄いラッパーのまま（142 → 24 行）

## 効果

| | 現状（失敗） | 本 PR |
|---|---|---|
| 総実行時間 | 約 39 分 | 約 23 分 |
| artifact 転送 | 30 分 | 0 分 |
| Steam deploy | 毎回失敗（ログ上は success） | 実際にアップロードされる |
| Win/Mac ビルド | 並列 (9 分) | 順次 (18 分) |

並列性と引き換えに artifact コストを消し、deploy を実際に動かす。

## Test plan
- [ ] マージ後、`Steam Deploy 🎮` が単一ジョブで通ること
- [ ] Steamworks の Builds 画面に Win/Mac 両 depot がアップロードされていること（以前は毎回失敗していたので初めての成功になる）
- [ ] バージョン文字列（タグ + JST + 短 SHA）が従来通り埋め込まれていること

## Notes
- `config-vdf` secret は事前に 2FA を突破した config.vdf を base64 化した文字列として Steamworks Build Account から取得したもの（既存 secret 再利用）
- 失敗時は steamcmd のログを見て認証/ネットワーク/depot ID のどれが原因かを切り分けてください

🤖 Generated with [Claude Code](https://claude.com/claude-code)