### PR TITLE
feat: ノベルパートに SE 再生と選択結果の永続化を追加

### DIFF
--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -1,478 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &349495271076974098
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 617654765780270993}
-  - component: {fileID: 7347652911731380631}
-  - component: {fileID: 5969783544869246780}
-  m_Layer: 0
-  m_Name: MessageWindow
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &617654765780270993
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 349495271076974098}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2984125136027013798}
-  - {fileID: 5835709369622577756}
-  m_Father: {fileID: 7376430804190998633}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -345}
-  m_SizeDelta: {x: 2000, y: 350}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &7347652911731380631
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 349495271076974098}
-  m_CullTransparentMesh: 1
---- !u!114 &5969783544869246780
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 349495271076974098}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: ad9a0650820fd467699f6b73fe76e431, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!1 &2081024076701299709
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2984125136027013798}
-  - component: {fileID: 4359840747759146873}
-  - component: {fileID: 7172017768859041692}
-  m_Layer: 0
-  m_Name: NameLabel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2984125136027013798
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2081024076701299709}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 617654765780270993}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -655, y: 137}
-  m_SizeDelta: {x: 420, y: 62}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4359840747759146873
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2081024076701299709}
-  m_CullTransparentMesh: 1
---- !u!114 &7172017768859041692
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2081024076701299709}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 4096
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_characterHorizontalScale: 1
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &6716678882584917467
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5835709369622577756}
-  - component: {fileID: 6513097489142510738}
-  - component: {fileID: 2868043861240887093}
-  m_Layer: 0
-  m_Name: MessageLabel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5835709369622577756
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6716678882584917467}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 617654765780270993}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 30, y: -45}
-  m_SizeDelta: {x: 1450, y: 200}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6513097489142510738
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6716678882584917467}
-  m_CullTransparentMesh: 1
---- !u!114 &2868043861240887093
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6716678882584917467}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 30
-  m_fontSizeBase: 30
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_characterHorizontalScale: 1
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &7207363111601382205
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7376430804190998633}
-  - component: {fileID: 5428266411713009942}
-  m_Layer: 0
-  m_Name: NovelKitView
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7376430804190998633
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7207363111601382205}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9100011}
-  - {fileID: 9100021}
-  - {fileID: 617654765780270993}
-  - {fileID: 4554064236941310087}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &5428266411713009942
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7207363111601382205}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a5e892d2738544a77a56608892a39d82, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Novel.View::Novel.View.NovelMessageView
-  window: {fileID: 349495271076974098}
-  nameLabel: {fileID: 7172017768859041692}
-  messageLabel: {fileID: 2868043861240887093}
-  shakeAmplitude: 3
-  waveAmplitude: 4
-  waveSpeed: 6
-  choiceContainer: {fileID: 4554064236941310087}
-  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
---- !u!1 &9150722108618635631
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4554064236941310087}
-  - component: {fileID: 1618035755148158162}
-  m_Layer: 0
-  m_Name: ChoiceContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4554064236941310087
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9150722108618635631}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7376430804190998633}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 100}
-  m_SizeDelta: {x: 1000, y: 600}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1618035755148158162
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9150722108618635631}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.VerticalLayoutGroup
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 20
-  m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!1 &9100010
 GameObject:
   m_ObjectHideFlags: 0
@@ -563,6 +90,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DialogBackgroundView
   fadeDuration: 0.5
+--- !u!114 &9100015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9100010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 43bab4d7681343019348c68c4986e2e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NovelKitBackgroundView
+  backgroundView: {fileID: 9100014}
 --- !u!1 &9100020
 GameObject:
   m_ObjectHideFlags: 0
@@ -1059,16 +599,564 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &9100015
+--- !u!1 &349495271076974098
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 617654765780270993}
+  - component: {fileID: 7347652911731380631}
+  - component: {fileID: 5969783544869246780}
+  m_Layer: 0
+  m_Name: MessageWindow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &617654765780270993
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 349495271076974098}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2984125136027013798}
+  - {fileID: 5835709369622577756}
+  m_Father: {fileID: 7376430804190998633}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -345}
+  m_SizeDelta: {x: 2000, y: 350}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7347652911731380631
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 349495271076974098}
+  m_CullTransparentMesh: 1
+--- !u!114 &5969783544869246780
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9100010}
+  m_GameObject: {fileID: 349495271076974098}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 43bab4d7681343019348c68c4986e2e6, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::NovelKitBackgroundView
-  backgroundView: {fileID: 9100014}
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ad9a0650820fd467699f6b73fe76e431, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2081024076701299709
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2984125136027013798}
+  - component: {fileID: 4359840747759146873}
+  - component: {fileID: 7172017768859041692}
+  m_Layer: 0
+  m_Name: NameLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2984125136027013798
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081024076701299709}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 617654765780270993}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -655, y: 137}
+  m_SizeDelta: {x: 420, y: 62}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4359840747759146873
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081024076701299709}
+  m_CullTransparentMesh: 1
+--- !u!114 &7172017768859041692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081024076701299709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6716678882584917467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5835709369622577756}
+  - component: {fileID: 6513097489142510738}
+  - component: {fileID: 2868043861240887093}
+  m_Layer: 0
+  m_Name: MessageLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5835709369622577756
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6716678882584917467}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 617654765780270993}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 30, y: -45}
+  m_SizeDelta: {x: 1450, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6513097489142510738
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6716678882584917467}
+  m_CullTransparentMesh: 1
+--- !u!114 &2868043861240887093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6716678882584917467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7207363111601382205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7376430804190998633}
+  - component: {fileID: 5428266411713009942}
+  - component: {fileID: 6304849522132463678}
+  m_Layer: 0
+  m_Name: NovelKitView
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7376430804190998633
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7207363111601382205}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9100011}
+  - {fileID: 9100021}
+  - {fileID: 617654765780270993}
+  - {fileID: 4554064236941310087}
+  - {fileID: 9149412424436397180}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5428266411713009942
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7207363111601382205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e892d2738544a77a56608892a39d82, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Novel.View::Novel.View.NovelMessageView
+  window: {fileID: 349495271076974098}
+  nameLabel: {fileID: 7172017768859041692}
+  messageLabel: {fileID: 2868043861240887093}
+  shakeAmplitude: 3
+  waveAmplitude: 4
+  waveSpeed: 6
+  choiceContainer: {fileID: 4554064236941310087}
+  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
+--- !u!114 &6304849522132463678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7207363111601382205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b24bd844c34050badec050a89104b8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NovelKitAudioChannel
+  seManager: {fileID: 599100507661183887}
+--- !u!1 &9150722108618635631
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4554064236941310087}
+  - component: {fileID: 1618035755148158162}
+  m_Layer: 0
+  m_Name: ChoiceContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4554064236941310087
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9150722108618635631}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7376430804190998633}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 100}
+  m_SizeDelta: {x: 1000, y: 600}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1618035755148158162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9150722108618635631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.VerticalLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 20
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1001 &8512021992826896100
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7376430804190998633}
+    m_Modifications:
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4832695855774412043, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+      propertyPath: m_Name
+      value: NovelSeManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+--- !u!114 &599100507661183887 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9110967157870876011, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+  m_PrefabInstance: {fileID: 8512021992826896100}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0089e532b114d4f817f50b04aa9c354, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &9149412424436397180 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
+  m_PrefabInstance: {fileID: 8512021992826896100}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Scenarios/prologue.rb
+++ b/Assets/Resources/Scenarios/prologue.rb
@@ -10,7 +10,19 @@ portrait :alv, 'Character/Alv/Normal.png'
 
 say :cerica, 'ここは……どこだ？', 'Character/Cerica/Sad.png'
 say :alv, '応える声は、ない。'
+
+se 'DoorArrivalBell'
 say :cerica, '<w=0.5>とにかく、進むしかないか。', 'Character/Cerica/Smile.png'
+
+# key を渡すと選択結果が安定キーで state に残り、セーブ対象になる
+choose(['扉を開ける', 'その場に留まる'], key: :prologue_door)
+
+if val(:prologue_door) == 0
+  se 'DoorArrival'
+  say :cerica, '……行こう。'
+else
+  say :cerica, '……もう少し、ここにいる。'
+end
 
 exit_chara :alv
 bg 'Background/LobbyDark.jpg'

--- a/Assets/Scenes/NovelKitScene.unity
+++ b/Assets/Scenes/NovelKitScene.unity
@@ -454,6 +454,7 @@ MonoBehaviour:
   view: {fileID: 42359165}
   portraitView: {fileID: 7979043816502831967}
   backgroundView: {fileID: 7979043816502831966}
+  audioChannel: {fileID: 7979043816502831968}
   catalog: {fileID: 11400000, guid: 41ead546b054c402881676586cb601df, type: 2}
   scenarioKey: prologue
 --- !u!4 &1929583714
@@ -590,6 +591,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2a8fdaf2da64990b851261dae407786, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitPortraitView
+--- !u!114 &7979043816502831968 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6304849522132463678, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
+  m_PrefabInstance: {fileID: 7979043816502831965}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b24bd844c34050badec050a89104b8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NovelKitAudioChannel
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Game/Core/NovelProgressData.cs
+++ b/Assets/Scripts/Game/Core/NovelProgressData.cs
@@ -7,6 +7,11 @@ using System.Collections.Generic;
 public class NovelProgressData
 {
     /// <summary>
+    /// novel-kit のフラグ / 既読スナップショット (NovelSaveSerializer 形式のJSON)
+    /// </summary>
+    public string NovelKitState { get; set; } = "";
+
+    /// <summary>
     /// ノベル選択結果のリスト
     /// </summary>
     private readonly List<NovelChoiceResult> _choiceResults;
@@ -45,5 +50,6 @@ public class NovelProgressData
     public void Reset()
     {
         _choiceResults.Clear();
+        NovelKitState = "";
     }
 }

--- a/Assets/Scripts/Game/Services/GameProgressService.cs
+++ b/Assets/Scripts/Game/Services/GameProgressService.cs
@@ -52,10 +52,23 @@ public class GameProgressService
     public List<NovelChoiceResult> GetChoiceResultsByScenario(string scenarioId) => _repository.NovelProgress.GetChoiceResultsByScenario(scenarioId);
 
     /// <summary>
+    /// novel-kit のフラグ / 既読スナップショットを取得
+    /// </summary>
+    public string GetNovelKitState() => _repository.NovelProgress.NovelKitState;
+
+    /// <summary>
     /// 獲得済みテーマリストを取得
     /// </summary>
-    /// <returns>獲得済みテーマのリスト</returns>
     public IReadOnlyList<AcquiredTheme> GetAcquiredThemes() => _repository.MemoryProgress.AcquiredThemes;
+
+    /// <summary>
+    /// novel-kit のフラグ / 既読スナップショットを記録してセーブ
+    /// </summary>
+    public void SaveNovelKitState(string state)
+    {
+        _repository.NovelProgress.NovelKitState = state;
+        _repository.SaveAll();
+    }
 
     /// <summary>
     /// 全データを初期状態にリセット（デバッグ用）

--- a/Assets/Scripts/Game/Services/GameStateRepository.cs
+++ b/Assets/Scripts/Game/Services/GameStateRepository.cs
@@ -92,6 +92,7 @@ public class GameStateRepository
 
         // ノベル進行データのロード
         NovelProgress.LoadFrom(loadedData.GetAllChoiceResults());
+        NovelProgress.NovelKitState = loadedData.NovelKitState;
 
         // 獲得テーマデータのロード
         MemoryProgress.Reset();
@@ -132,6 +133,7 @@ public class GameStateRepository
         {
             saveData.AddNovelChoiceResult(choiceResult);
         }
+        saveData.NovelKitState = NovelProgress.NovelKitState;
 
         // 獲得テーマをセーブデータに追加
         var savedThemes = MemoryProgress.AcquiredThemes.Select(theme => theme.ToSavedData());

--- a/Assets/Scripts/Game/Stats/GameSaveData.cs
+++ b/Assets/Scripts/Game/Stats/GameSaveData.cs
@@ -22,10 +22,22 @@ public class GameSaveData
     [Header("獲得記憶テーマ")]
     [SerializeField] private List<SavedAcquiredTheme> acquiredThemes = new();
 
+    [Header("novel-kit のフラグ / 既読")]
+    [SerializeField] private string novelKitState = "";
+
     // プロパティ
     public int CurrentStep => currentStep;
     public List<NovelChoiceResult> NovelChoiceResults => novelChoiceResults;
     public IReadOnlyList<SavedAcquiredTheme> AcquiredThemes => acquiredThemes;
+
+    /// <summary>
+    /// novel-kit の状態スナップショット (NovelSaveSerializer 形式のJSON)
+    /// </summary>
+    public string NovelKitState
+    {
+        get => novelKitState;
+        set => novelKitState = value;
+    }
 
     /// <summary>
     /// カードが閲覧済みかチェック

--- a/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
+++ b/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using Novel.Runtime;
@@ -11,12 +12,16 @@ public class NovelKitAudioChannel : MonoBehaviour, IAudioChannel
 {
     [SerializeField] private NovelSeManager seManager;
 
-    public void PlayBgm(string bgmKey) { }
-    public void StopBgm() { }
+    private bool _bgmWarned;
+
+    public void StopBgm() => WarnBgmUnsupported();
+    public void PlayBgm(string bgmKey) => WarnBgmUnsupported();
 
     // 再生完了まで待つとセリフ送りが止まるため、鳴らし始めたら即座に次へ進める
     public UniTask PlaySeAsync(string seKey, CancellationToken ct)
     {
+        if (ct.IsCancellationRequested) return UniTask.FromCanceled(ct);
+
         seManager.PlaySe(seKey);
         return UniTask.CompletedTask;
     }
@@ -25,8 +30,18 @@ public class NovelKitAudioChannel : MonoBehaviour, IAudioChannel
     {
         for (var i = 0; i < count; i++)
         {
+            ct.ThrowIfCancellationRequested();
             seManager.PlaySe(seKey);
-            if (i < count - 1) await UniTask.Delay((int)(interval * 1000), cancellationToken: ct);
+            if (i < count - 1) await UniTask.Delay(TimeSpan.FromSeconds(interval), cancellationToken: ct);
         }
+    }
+
+    // シナリオ側の bgm 呼び出しミスに気付けるよう、無音で捨てず一度だけ警告する
+    private void WarnBgmUnsupported()
+    {
+        if (_bgmWarned) return;
+
+        _bgmWarned = true;
+        Debug.LogWarning("[NovelKitAudioChannel] BGM は未対応のため無視した");
     }
 }

--- a/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
+++ b/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using Novel.Runtime;
+using UnityEngine;
+
+/// <summary>
+/// novel-kit のIAudioChannel実装
+/// 既存のNovelSeManagerへSE再生を委譲する (BGMはノベル側で扱わないため未対応)
+/// </summary>
+public class NovelKitAudioChannel : MonoBehaviour, IAudioChannel
+{
+    [SerializeField] private NovelSeManager seManager;
+
+    public void PlayBgm(string bgmKey) { }
+    public void StopBgm() { }
+
+    // 再生完了まで待つとセリフ送りが止まるため、鳴らし始めたら即座に次へ進める
+    public UniTask PlaySeAsync(string seKey, CancellationToken ct)
+    {
+        seManager.PlaySe(seKey);
+        return UniTask.CompletedTask;
+    }
+
+    public async UniTask PlaySeLoopAsync(string seKey, float interval, int count, CancellationToken ct)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            seManager.PlaySe(seKey);
+            if (i < count - 1) await UniTask.Delay((int)(interval * 1000), cancellationToken: ct);
+        }
+    }
+}

--- a/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs.meta
+++ b/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09b24bd844c34050badec050a89104b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
@@ -12,16 +12,17 @@ public class NovelKitBackgroundView : MonoBehaviour, IBackgroundView
     [SerializeField] private DialogBackgroundView backgroundView;
 
     // イベントCGも背景と同じ全画面レイヤーで表示する (専用素材が増えたら分離する)
-    public UniTask ShowStillAsync(Sprite sprite, CancellationToken ct) => ShowAsync(sprite, ct);
+    public UniTask ShowStillAsync(ResolvedSprite still, CancellationToken ct) => ShowAsync(still, ct);
 
-    public async UniTask ShowAsync(Sprite sprite, CancellationToken ct)
+    public async UniTask ShowAsync(ResolvedSprite background, CancellationToken ct)
     {
-        if (!sprite)
+        if (!background.IsLoaded)
         {
-            Debug.LogWarning("[NovelKitBackgroundView] 背景の解決に失敗");
+            // 消去指示 (空キー) は黒背景のまま据え置き、ロード失敗だけ警告する
+            if (!background.IsCleared) Debug.LogWarning($"[NovelKitBackgroundView] 背景の解決に失敗: {background.Key}");
             return;
         }
 
-        await backgroundView.SetBackground(sprite).AttachExternalCancellation(ct);
+        await backgroundView.SetBackground(background.Sprite).AttachExternalCancellation(ct);
     }
 }

--- a/Assets/Scripts/NovelKit/NovelKitLifetimeScope.cs
+++ b/Assets/Scripts/NovelKit/NovelKitLifetimeScope.cs
@@ -16,6 +16,7 @@ public class NovelKitLifetimeScope : LifetimeScope
     [SerializeField] private NovelMessageView view;
     [SerializeField] private NovelKitPortraitView portraitView;
     [SerializeField] private NovelKitBackgroundView backgroundView;
+    [SerializeField] private NovelKitAudioChannel audioChannel;
     [SerializeField] private ScriptableCharacterCatalog catalog;
     [SerializeField] private string scenarioKey = "prologue";
 
@@ -31,6 +32,7 @@ public class NovelKitLifetimeScope : LifetimeScope
         builder.RegisterInstance<ISpriteLoader>(new AddressablesSpriteLoader(SPRITE_ADDRESS_ROOT));
         builder.RegisterComponent(portraitView).As<IPortraitView>();
         builder.RegisterComponent(backgroundView).As<IBackgroundView>();
+        builder.RegisterComponent(audioChannel).As<IAudioChannel>();
 
         builder.RegisterInstance<ICharacterCatalog>(catalog);
         builder.RegisterEntryPoint<NovelKitStarter>().WithParameter(scenarioKey);

--- a/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
@@ -40,17 +40,19 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitView
         return UniTask.CompletedTask;
     }
 
-    public async UniTask ShowAsync(int slotIndex, string character, Sprite sprite, CancellationToken ct)
+    public async UniTask ShowAsync(int slotIndex, string character, ResolvedSprite portrait, CancellationToken ct)
     {
         if (!IsValidSlot(slotIndex)) return;
-        if (!sprite)
+        if (!portrait.IsLoaded)
         {
-            Debug.LogWarning($"[NovelKitPortraitView] 立ち絵の解決に失敗: {character}");
+            // 消去指示 (空キー) は退場として扱い、ロード失敗だけ警告する
+            if (portrait.IsCleared) await HideAsync(slotIndex, ct);
+            else Debug.LogWarning($"[NovelKitPortraitView] 立ち絵の解決に失敗: {character} ({portrait.Key})");
             return;
         }
 
         var slot = slots[slotIndex];
-        await slot.image.CrossfadeAsync(sprite, ct);
+        await slot.image.CrossfadeAsync(portrait.Sprite, ct);
         if (_visibleSlots.Add(slotIndex))
             await slot.group.FadeIn(fadeDuration).ToUniTask(cancellationToken: ct);
     }

--- a/Assets/Scripts/NovelKit/NovelKitStarter.cs
+++ b/Assets/Scripts/NovelKit/NovelKitStarter.cs
@@ -5,23 +5,35 @@ using Novel.Runtime;
 using VContainer.Unity;
 
 /// <summary>
-/// 起動時に指定シナリオの再生を開始する
+/// 起動時に保存済みフラグを復元してシナリオ再生を開始し、完了時に状態を保存する
 /// </summary>
 public class NovelKitStarter : IStartable, IDisposable
 {
     private readonly INovelScenarioRunner _runner;
+    private readonly GameProgressService _gameProgressService;
     private readonly string _scenarioKey;
     private readonly CancellationTokenSource _cts = new();
 
-    public NovelKitStarter(INovelScenarioRunner runner, string scenarioKey)
+    public NovelKitStarter(INovelScenarioRunner runner, GameProgressService gameProgressService, string scenarioKey)
     {
         _runner = runner;
+        _gameProgressService = gameProgressService;
         _scenarioKey = scenarioKey;
+    }
+
+    private async UniTaskVoid PlayAsync(CancellationToken ct)
+    {
+        // 分岐リプレイを決定的にするため、再生前にフラグを復元しておく
+        if (NovelSaveSerializer.TryDeserialize(_gameProgressService.GetNovelKitState(), out var snapshot))
+            _runner.RestoreState(snapshot);
+
+        await _runner.PlayAsync(_scenarioKey, ct);
+        _gameProgressService.SaveNovelKitState(NovelSaveSerializer.Serialize(_runner.CaptureState()));
     }
 
     public void Start()
     {
-        _runner.PlayAsync(_scenarioKey, _cts.Token).Forget();
+        PlayAsync(_cts.Token).Forget();
     }
 
     public void Dispose()

--- a/Assets/Scripts/NovelKit/NovelKitStarter.cs
+++ b/Assets/Scripts/NovelKit/NovelKitStarter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using Novel.Runtime;
+using UnityEngine;
 using VContainer.Unity;
 
 /// <summary>
@@ -21,7 +22,7 @@ public class NovelKitStarter : IStartable, IDisposable
         _scenarioKey = scenarioKey;
     }
 
-    private async UniTaskVoid PlayAsync(CancellationToken ct)
+    private async UniTask PlayAsync(CancellationToken ct)
     {
         // 分岐リプレイを決定的にするため、再生前にフラグを復元しておく
         if (NovelSaveSerializer.TryDeserialize(_gameProgressService.GetNovelKitState(), out var snapshot))
@@ -33,7 +34,7 @@ public class NovelKitStarter : IStartable, IDisposable
 
     public void Start()
     {
-        PlayAsync(_cts.Token).Forget();
+        PlayAsync(_cts.Token).Forget(Debug.LogException);
     }
 
     public void Dispose()

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -22,7 +22,7 @@
     "com.unity.visualeffectgraph": "17.3.0",
     "com.unity.visualscripting": "1.9.9",
     "com.unityroom.client": "https://github.com/naichilab/unityroom-client-library.git?path=Assets/unityroom",
-    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#80efafa2d2480c3bd75dae68f40827933ba75fc5",
+    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#1dd19601caf55cc07f543e44fce7e69354ceaf54",
     "com.void2610.unity-template": "https://github.com/void2610/my-unity-template.git",
     "com.yujiap.unity-toolbar-extension": "https://github.com/void2610/UnityToolbarExtension.git",
     "io.github.hatayama.uloopmcp": "https://github.com/hatayama/uLoopMCP.git?path=/Packages/src",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -450,13 +450,13 @@
       "hash": "c4dea57e1c27567bac512e090a356b08abf83d0b"
     },
     "com.void2610.novel-kit": {
-      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#80efafa2d2480c3bd75dae68f40827933ba75fc5",
+      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#1dd19601caf55cc07f543e44fce7e69354ceaf54",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.ugui": "2.0.0"
       },
-      "hash": "80efafa2d2480c3bd75dae68f40827933ba75fc5"
+      "hash": "1dd19601caf55cc07f543e44fce7e69354ceaf54"
     },
     "com.void2610.unity-template": {
       "version": "https://github.com/void2610/my-unity-template.git",


### PR DESCRIPTION
## 概要

Excel ベースのノベル機能を novel-kit へ置き換えるための第三歩として、SE・選択肢・選択結果の保存を揃える。

## 変更点

- SE 再生を実装し、既存の効果音マネージャへ委譲した
  - 再生完了を待つとセリフ送りが止まるため、鳴らし始めたら次へ進める
- 選択肢はパッケージ標準の View がそのまま使えるため、配線のみで有効化
- フラグ / 既読のスナップショットを既存のセーブ経路に載せ、起動時の復元と完走時の保存を追加
  - 選択結果は `choose(key:)` で安定キーへ書く形にした。これで分岐条件も周回時の復元も同じ器で扱える
- novel-kit を最新へ更新し、スプライト facet の新しい引数型に追従 (消去指示とロード失敗を区別できるようになった)

## 補足

作業中に **novel-kit 側で選択分岐が常に同じ側へ倒れる不具合**を発見し、[novel-kit#19](https://github.com/void2610/novel-kit/pull/19) で修正済み。C# が書いた状態を Ruby から読めていなかったもので、本 PR はその修正を含むバージョンを参照している。

## 動作確認

- [x] 選択肢を選ぶと選んだ側へ分岐する (index0 / index1 の両方)
- [x] 完走時にフラグと既読が保存され、再起動で復元される
- [ ] CI (unity-compile / format-check / WebGL) がグリーン