### PR TITLE
feat: ノベルにオート・スキップと送り待ち表示を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ tools/**/obj/
 !/Assets/Packages/com.discord.partnersdk.meta
 # System.CodeDom は Editor 除外の手動設定を持つため dll の meta のみ追跡 (Unity 標準 System との CS0433 回避)
 !/Assets/Packages/System.CodeDom.*/**/*.dll.meta
+outputs/

--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -631,8 +631,8 @@ RectTransform:
   m_Children:
   - {fileID: 2984125136027013798}
   - {fileID: 5835709369622577756}
-  - {fileID: 2790610410611555706}
-  - {fileID: 357454316287240592}
+  - {fileID: 4769167257489664853}
+  - {fileID: 334653373061785594}
   m_Father: {fileID: 7376430804190998633}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -678,211 +678,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &1882938678514536721
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 357454316287240592}
-  - component: {fileID: 2259335788997485646}
-  - component: {fileID: 5813485685382509122}
-  - component: {fileID: 5311479003436499119}
-  - component: {fileID: 2478118818059875587}
-  m_Layer: 5
-  m_Name: SkipButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &357454316287240592
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882938678514536721}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 617654765780270993}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -40, y: -20}
-  m_SizeDelta: {x: 125, y: 40}
-  m_Pivot: {x: 1, y: 1}
---- !u!222 &2259335788997485646
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882938678514536721}
-  m_CullTransparentMesh: 1
---- !u!114 &5813485685382509122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882938678514536721}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "\u30B9\u30AD\u30C3\u30D7"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 25
-  m_fontSizeBase: 25
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 10
-  m_fontSizeMax: 30
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_characterHorizontalScale: 1
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &5311479003436499119
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882938678514536721}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 5813485685382509122}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &2478118818059875587
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882938678514536721}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1f7da71234e2b4ff4b7a25d8714f9f94, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  hoverSe: {fileID: 8300000, guid: 0523a9b80961b4235947ab2c1b4e918f, type: 3}
-  hoverVolume: 0.1
-  clickSe: {fileID: 8300000, guid: 3201935c4382f4b48b1361533e6f0015, type: 3}
-  clickVolume: 0.5
-  randomizePitch: 0
-  isOnlyRandomizeOnHover: 0
-  minPitch: 0.9
-  maxPitch: 1.1
-  hoverCooldown: 0.1
-  isImportantButton: 0
 --- !u!1 &2081024076701299709
 GameObject:
   m_ObjectHideFlags: 0
@@ -1020,211 +815,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &2749859470322073935
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2790610410611555706}
-  - component: {fileID: 8859183558829806186}
-  - component: {fileID: 3976227826654340182}
-  - component: {fileID: 6556256826410091183}
-  - component: {fileID: 2178616876557739204}
-  m_Layer: 5
-  m_Name: AutoButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2790610410611555706
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2749859470322073935}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 617654765780270993}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -180, y: -20}
-  m_SizeDelta: {x: 125, y: 40}
-  m_Pivot: {x: 1, y: 1}
---- !u!222 &8859183558829806186
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2749859470322073935}
-  m_CullTransparentMesh: 1
---- !u!114 &3976227826654340182
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2749859470322073935}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "\u30AA\u30FC\u30C8"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 25
-  m_fontSizeBase: 25
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 10
-  m_fontSizeMax: 30
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_characterHorizontalScale: 1
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &6556256826410091183
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2749859470322073935}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 3976227826654340182}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &2178616876557739204
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2749859470322073935}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1f7da71234e2b4ff4b7a25d8714f9f94, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  hoverSe: {fileID: 8300000, guid: 0523a9b80961b4235947ab2c1b4e918f, type: 3}
-  hoverVolume: 0.1
-  clickSe: {fileID: 8300000, guid: 3201935c4382f4b48b1361533e6f0015, type: 3}
-  clickVolume: 0.5
-  randomizePitch: 0
-  isOnlyRandomizeOnHover: 0
-  minPitch: 0.9
-  maxPitch: 1.1
-  hoverCooldown: 0.1
-  isImportantButton: 0
 --- !u!1 &6716678882584917467
 GameObject:
   m_ObjectHideFlags: 0
@@ -1434,9 +1024,9 @@ MonoBehaviour:
   messageLabel: {fileID: 2868043861240887093}
   choiceContainer: {fileID: 4554064236941310087}
   choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
-  autoButton: {fileID: 6556256826410091183}
-  autoButtonText: {fileID: 3976227826654340182}
-  skipButton: {fileID: 5311479003436499119}
+  autoButton: {fileID: 3894076922515142720}
+  autoButtonText: {fileID: 2411714196747194663}
+  skipButton: {fileID: 8106790999200380143}
   autoButtonNormalColor: {r: 1, g: 1, b: 1, a: 1}
   autoButtonActiveColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
   charSpeed: 0.03
@@ -1504,6 +1094,247 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1001 &1287812435991548695
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 617654765780270993}
+    m_Modifications:
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -40
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3936881839985094161, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_Name
+      value: SkipButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 8515333814100872863, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_text
+      value: "\u30B9\u30AD\u30C3\u30D7"
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+--- !u!224 &334653373061785594 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+  m_PrefabInstance: {fileID: 1287812435991548695}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8106790999200380143 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7016082516238362616, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+  m_PrefabInstance: {fileID: 1287812435991548695}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &6292843370565394360
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 617654765780270993}
+    m_Modifications:
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3936881839985094161, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_Name
+      value: AutoButton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+--- !u!114 &2411714196747194663 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8515333814100872863, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+  m_PrefabInstance: {fileID: 6292843370565394360}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3894076922515142720 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7016082516238362616, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+  m_PrefabInstance: {fileID: 6292843370565394360}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &4769167257489664853 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+  m_PrefabInstance: {fileID: 6292843370565394360}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8512021992826896100
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -841,13 +841,13 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5124659019958297112}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 617654765780270993}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}

--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -1112,27 +1112,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 125
+      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 40
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1164,11 +1164,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -40
+      value: 748
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -20
+      value: 177
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1189,6 +1189,14 @@ PrefabInstance:
     - target: {fileID: 8515333814100872863, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_text
       value: "\u30B9\u30AD\u30C3\u30D7"
+      objectReference: {fileID: 0}
+    - target: {fileID: 8515333814100872863, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_fontSize
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 8515333814100872863, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 40
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1229,27 +1237,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 125
+      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 40
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1281,11 +1289,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -180
+      value: 563
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -20
+      value: 177
       objectReference: {fileID: 0}
     - target: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1302,6 +1310,14 @@ PrefabInstance:
     - target: {fileID: 3936881839985094161, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
       propertyPath: m_Name
       value: AutoButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 8515333814100872863, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_fontSize
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 8515333814100872863, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 40
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -631,6 +631,8 @@ RectTransform:
   m_Children:
   - {fileID: 2984125136027013798}
   - {fileID: 5835709369622577756}
+  - {fileID: 2790610410611555706}
+  - {fileID: 357454316287240592}
   m_Father: {fileID: 7376430804190998633}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -676,6 +678,211 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1882938678514536721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 357454316287240592}
+  - component: {fileID: 2259335788997485646}
+  - component: {fileID: 5813485685382509122}
+  - component: {fileID: 5311479003436499119}
+  - component: {fileID: 2478118818059875587}
+  m_Layer: 5
+  m_Name: SkipButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &357454316287240592
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882938678514536721}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 617654765780270993}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -40, y: -20}
+  m_SizeDelta: {x: 125, y: 40}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &2259335788997485646
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882938678514536721}
+  m_CullTransparentMesh: 1
+--- !u!114 &5813485685382509122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882938678514536721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u30B9\u30AD\u30C3\u30D7"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 25
+  m_fontSizeBase: 25
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 30
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5311479003436499119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882938678514536721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5813485685382509122}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2478118818059875587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882938678514536721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f7da71234e2b4ff4b7a25d8714f9f94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hoverSe: {fileID: 8300000, guid: 0523a9b80961b4235947ab2c1b4e918f, type: 3}
+  hoverVolume: 0.1
+  clickSe: {fileID: 8300000, guid: 3201935c4382f4b48b1361533e6f0015, type: 3}
+  clickVolume: 0.5
+  randomizePitch: 0
+  isOnlyRandomizeOnHover: 0
+  minPitch: 0.9
+  maxPitch: 1.1
+  hoverCooldown: 0.1
+  isImportantButton: 0
 --- !u!1 &2081024076701299709
 GameObject:
   m_ObjectHideFlags: 0
@@ -813,6 +1020,211 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2749859470322073935
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2790610410611555706}
+  - component: {fileID: 8859183558829806186}
+  - component: {fileID: 3976227826654340182}
+  - component: {fileID: 6556256826410091183}
+  - component: {fileID: 2178616876557739204}
+  m_Layer: 5
+  m_Name: AutoButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2790610410611555706
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2749859470322073935}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 617654765780270993}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -180, y: -20}
+  m_SizeDelta: {x: 125, y: 40}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &8859183558829806186
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2749859470322073935}
+  m_CullTransparentMesh: 1
+--- !u!114 &3976227826654340182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2749859470322073935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u30AA\u30FC\u30C8"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_sharedMaterial: {fileID: 1947302341603136683, guid: ab12ebeeedda341c9ad4c1e3f4368cf4, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 25
+  m_fontSizeBase: 25
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 30
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6556256826410091183
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2749859470322073935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3976227826654340182}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2178616876557739204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2749859470322073935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f7da71234e2b4ff4b7a25d8714f9f94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hoverSe: {fileID: 8300000, guid: 0523a9b80961b4235947ab2c1b4e918f, type: 3}
+  hoverVolume: 0.1
+  clickSe: {fileID: 8300000, guid: 3201935c4382f4b48b1361533e6f0015, type: 3}
+  clickVolume: 0.5
+  randomizePitch: 0
+  isOnlyRandomizeOnHover: 0
+  minPitch: 0.9
+  maxPitch: 1.1
+  hoverCooldown: 0.1
+  isImportantButton: 0
 --- !u!1 &6716678882584917467
 GameObject:
   m_ObjectHideFlags: 0
@@ -1022,7 +1434,13 @@ MonoBehaviour:
   messageLabel: {fileID: 2868043861240887093}
   choiceContainer: {fileID: 4554064236941310087}
   choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
+  autoButton: {fileID: 6556256826410091183}
+  autoButtonText: {fileID: 3976227826654340182}
+  skipButton: {fileID: 5311479003436499119}
+  autoButtonNormalColor: {r: 1, g: 1, b: 1, a: 1}
+  autoButtonActiveColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
   charSpeed: 0.03
+  autoNextDelay: 3
   typingSeName: Dialog2
 --- !u!1 &9150722108618635631
 GameObject:

--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -633,6 +633,7 @@ RectTransform:
   - {fileID: 5835709369622577756}
   - {fileID: 4769167257489664853}
   - {fileID: 334653373061785594}
+  - {fileID: 7297636079338532978}
   m_Father: {fileID: 7376430804190998633}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -815,6 +816,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5124659019958297112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7297636079338532978}
+  - component: {fileID: 3870577571482104839}
+  - component: {fileID: 1230134736341265654}
+  m_Layer: 0
+  m_Name: NextIndicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7297636079338532978
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5124659019958297112}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 617654765780270993}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3870577571482104839
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5124659019958297112}
+  m_CullTransparentMesh: 1
+--- !u!114 &1230134736341265654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5124659019958297112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6716678882584917467
 GameObject:
   m_ObjectHideFlags: 0
@@ -1022,6 +1098,7 @@ MonoBehaviour:
   window: {fileID: 349495271076974098}
   nameLabel: {fileID: 7172017768859041692}
   messageLabel: {fileID: 2868043861240887093}
+  nextIndicator: {fileID: 5124659019958297112}
   choiceContainer: {fileID: 4554064236941310087}
   choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
   autoButton: {fileID: 3894076922515142720}

--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -60,7 +60,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -710,8 +710,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -655, y: 137}
-  m_SizeDelta: {x: 420, y: 62}
+  m_AnchoredPosition: {x: -550, y: 137}
+  m_SizeDelta: {x: 330, y: 55}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4359840747759146873
 CanvasRenderer:
@@ -847,8 +847,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 30, y: -45}
-  m_SizeDelta: {x: 1450, y: 200}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 1350, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6513097489142510738
 CanvasRenderer:
@@ -905,8 +905,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 30
-  m_fontSizeBase: 30
+  m_fontSize: 40
+  m_fontSizeBase: 40
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -959,8 +959,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7376430804190998633}
-  - component: {fileID: 5428266411713009942}
   - component: {fileID: 6304849522132463678}
+  - component: {fileID: 6903809405870213346}
   m_Layer: 0
   m_Name: NovelKitView
   m_TagString: Untagged
@@ -992,26 +992,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &5428266411713009942
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7207363111601382205}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a5e892d2738544a77a56608892a39d82, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Novel.View::Novel.View.NovelMessageView
-  window: {fileID: 349495271076974098}
-  nameLabel: {fileID: 7172017768859041692}
-  messageLabel: {fileID: 2868043861240887093}
-  shakeAmplitude: 3
-  waveAmplitude: 4
-  waveSpeed: 6
-  choiceContainer: {fileID: 4554064236941310087}
-  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
 --- !u!114 &6304849522132463678
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1025,6 +1005,25 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitAudioChannel
   seManager: {fileID: 599100507661183887}
+--- !u!114 &6903809405870213346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7207363111601382205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23b33c23aa16e477f812dda1afa3d2f4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NovelKitMessageView
+  window: {fileID: 349495271076974098}
+  nameLabel: {fileID: 7172017768859041692}
+  messageLabel: {fileID: 2868043861240887093}
+  choiceContainer: {fileID: 4554064236941310087}
+  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
+  charSpeed: 0.03
+  typingSeName: Dialog2
 --- !u!1 &9150722108618635631
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NovelKitScene.unity
+++ b/Assets/Scenes/NovelKitScene.unity
@@ -153,7 +153,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -469,6 +469,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 935884767}
     m_Modifications:
+    - target: {fileID: 9100013, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
       propertyPath: m_Name
       value: NovelView
@@ -649,7 +653,7 @@ MonoBehaviour:
   messageLabel: {fileID: 7979043816502831970}
   choiceContainer: {fileID: 7979043816502831969}
   choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
-  charsPerSecond: 40
+  charSpeed: 0.03
   typingSeName: Dialog2
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Assets/Scenes/NovelKitScene.unity
+++ b/Assets/Scenes/NovelKitScene.unity
@@ -345,7 +345,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0

--- a/Assets/Scenes/NovelKitScene.unity
+++ b/Assets/Scenes/NovelKitScene.unity
@@ -469,10 +469,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 935884767}
     m_Modifications:
-    - target: {fileID: 9100013, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-      propertyPath: m_Color.a
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
       propertyPath: m_Name
       value: NovelView
@@ -557,14 +553,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 5428266411713009942, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7979043816502831974}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
 --- !u!114 &7979043816502831966 stripped
 MonoBehaviour:
@@ -593,68 +585,23 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6304849522132463678, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
   m_PrefabInstance: {fileID: 7979043816502831965}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7979043816502831973}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 09b24bd844c34050badec050a89104b8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitAudioChannel
---- !u!224 &7979043816502831969 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4554064236941310087, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &7979043816502831970 stripped
+--- !u!114 &7979043816502831974 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2868043861240887093, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
+  m_CorrespondingSourceObject: {fileID: 6903809405870213346, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
   m_PrefabInstance: {fileID: 7979043816502831965}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
---- !u!114 &7979043816502831971 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7172017768859041692, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
---- !u!1 &7979043816502831972 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 349495271076974098, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &7979043816502831973 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &7979043816502831974
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7979043816502831973}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 23b33c23aa16e477f812dda1afa3d2f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitMessageView
-  window: {fileID: 7979043816502831972}
-  nameLabel: {fileID: 7979043816502831971}
-  messageLabel: {fileID: 7979043816502831970}
-  choiceContainer: {fileID: 7979043816502831969}
-  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
-  charSpeed: 0.03
-  typingSeName: Dialog2
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NovelKit/NovelKitAdvanceInput.cs
+++ b/Assets/Scripts/NovelKit/NovelKitAdvanceInput.cs
@@ -1,26 +1,55 @@
 using System;
+using Cysharp.Threading.Tasks;
 using R3;
 using VContainer.Unity;
+using Void2610.SettingsSystem;
+using Void2610.UnityTemplate;
 
 /// <summary>
-/// 送り入力をNovelKitMessageViewに橋渡しする
+/// 送り / オート / スキップの入力をNovelKitMessageViewに橋渡しする
 /// </summary>
 public class NovelKitAdvanceInput : IStartable, IDisposable
 {
     private readonly NovelKitMessageView _view;
     private readonly InputActionsProvider _inputActionsProvider;
+    private readonly IConfirmationDialog _confirmationDialog;
     private readonly CompositeDisposable _disposables = new();
 
-    public NovelKitAdvanceInput(NovelKitMessageView view, InputActionsProvider inputActionsProvider)
+    public NovelKitAdvanceInput(NovelKitMessageView view, InputActionsProvider inputActionsProvider,
+        IConfirmationDialog confirmationDialog)
     {
         _view = view;
         _inputActionsProvider = inputActionsProvider;
+        _confirmationDialog = confirmationDialog;
+    }
+
+    private async UniTaskVoid ConfirmAndSkip()
+    {
+        var confirmed = await _confirmationDialog.ShowDialog("現在のシナリオをスキップしますか？", "スキップ", "キャンセル");
+        if (!confirmed) return;
+
+        _view.BeginSkip();
     }
 
     public void Start()
     {
         _inputActionsProvider.UI.Advance.OnPerformedAsObservable()
             .Subscribe(_ => _view.Advance())
+            .AddTo(_disposables);
+
+        // 確認ダイアログ等が開いている間は誤爆させない
+        _inputActionsProvider.Novel.Auto.OnPerformedAsObservable()
+            .Where(_ => !BaseWindowView.HasActiveWindows)
+            .Subscribe(_ => _view.ToggleAutoMode())
+            .AddTo(_disposables);
+
+        _inputActionsProvider.Novel.Skip.OnPerformedAsObservable()
+            .Where(_ => !BaseWindowView.HasActiveWindows)
+            .Subscribe(_ => _view.RequestSkip())
+            .AddTo(_disposables);
+
+        _view.OnSkipRequested
+            .Subscribe(_ => ConfirmAndSkip().Forget())
             .AddTo(_disposables);
     }
 

--- a/Assets/Scripts/NovelKit/NovelKitAdvanceInput.cs
+++ b/Assets/Scripts/NovelKit/NovelKitAdvanceInput.cs
@@ -1,6 +1,7 @@
 using System;
 using Cysharp.Threading.Tasks;
 using R3;
+using UnityEngine;
 using VContainer.Unity;
 using Void2610.SettingsSystem;
 using Void2610.UnityTemplate;
@@ -15,6 +16,8 @@ public class NovelKitAdvanceInput : IStartable, IDisposable
     private readonly IConfirmationDialog _confirmationDialog;
     private readonly CompositeDisposable _disposables = new();
 
+    private bool _isConfirming;
+
     public NovelKitAdvanceInput(NovelKitMessageView view, InputActionsProvider inputActionsProvider,
         IConfirmationDialog confirmationDialog)
     {
@@ -23,12 +26,21 @@ public class NovelKitAdvanceInput : IStartable, IDisposable
         _confirmationDialog = confirmationDialog;
     }
 
-    private async UniTaskVoid ConfirmAndSkip()
+    // ボタンとキーの両方から要求が来るため、確認中の再要求は捨てる
+    private async UniTask ConfirmAndSkip()
     {
-        var confirmed = await _confirmationDialog.ShowDialog("現在のシナリオをスキップしますか？", "スキップ", "キャンセル");
-        if (!confirmed) return;
+        if (_isConfirming) return;
 
-        _view.BeginSkip();
+        _isConfirming = true;
+        try
+        {
+            var confirmed = await _confirmationDialog.ShowDialog("現在のシナリオをスキップしますか？", "スキップ", "キャンセル");
+            if (confirmed) _view.BeginSkip();
+        }
+        finally
+        {
+            _isConfirming = false;
+        }
     }
 
     public void Start()
@@ -49,7 +61,7 @@ public class NovelKitAdvanceInput : IStartable, IDisposable
             .AddTo(_disposables);
 
         _view.OnSkipRequested
-            .Subscribe(_ => ConfirmAndSkip().Forget())
+            .Subscribe(_ => ConfirmAndSkip().Forget(Debug.LogException))
             .AddTo(_disposables);
     }
 

--- a/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
@@ -5,14 +5,11 @@ using UnityEngine;
 
 /// <summary>
 /// novel-kit のIBackgroundView実装
-/// 既存のDialogBackgroundView (黒経由フェード) へ委譲する
+/// 既存のDialogBackgroundView (黒経由フェード) へ委譲する。イベントCGも同じ全画面レイヤーで出す
 /// </summary>
-public class NovelKitBackgroundView : MonoBehaviour, IBackgroundView
+public class NovelKitBackgroundView : MonoBehaviour, IBackgroundChannel, IStillChannel
 {
     [SerializeField] private DialogBackgroundView backgroundView;
-
-    // イベントCGも背景と同じ全画面レイヤーで表示する (専用素材が増えたら分離する)
-    public UniTask ShowStillAsync(ResolvedSprite still, CancellationToken ct) => ShowAsync(still, ct);
 
     public async UniTask ShowAsync(ResolvedSprite background, CancellationToken ct)
     {

--- a/Assets/Scripts/NovelKit/NovelKitLifetimeScope.cs
+++ b/Assets/Scripts/NovelKit/NovelKitLifetimeScope.cs
@@ -32,8 +32,8 @@ public class NovelKitLifetimeScope : LifetimeScope
 
         // novel-kit の既定 (Resourcesロード + 警告用no-op表示) を後勝ちで上書きする
         builder.RegisterInstance<ISpriteLoader>(new AddressablesSpriteLoader(SPRITE_ADDRESS_ROOT));
-        builder.RegisterComponent(portraitView).As<IPortraitView>();
-        builder.RegisterComponent(backgroundView).As<IBackgroundView>();
+        builder.RegisterComponent(portraitView).As<IPortraitChannel>();
+        builder.RegisterComponent(backgroundView).As<IBackgroundChannel>().As<IStillChannel>();
         builder.RegisterComponent(audioChannel).As<IAudioChannel>();
 
         builder.RegisterInstance<ICharacterCatalog>(catalog);

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using LitMotion;
+using LitMotion.Extensions;
 using Novel.Runtime;
 using R3;
 using TMPro;
@@ -18,6 +20,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     [SerializeField] private GameObject window;
     [SerializeField] private TextMeshProUGUI nameLabel;
     [SerializeField] private TextMeshProUGUI messageLabel;
+    [SerializeField] private GameObject nextIndicator;
     [SerializeField] private RectTransform choiceContainer;
     [SerializeField] private Button choiceButtonPrefab;
     [SerializeField] private Button autoButton;
@@ -39,6 +42,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     private readonly TextProgressController _progress = new();
     private readonly Subject<Unit> _onSkipRequested = new();
 
+    private MotionHandle _indicatorMotion;
     private bool _isAutoMode;
     private bool _isSkipMode;
 
@@ -74,6 +78,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     {
         window.SetActive(true);
         nameLabel.text = line.DisplayName ?? "";
+        HideNextIndicator();
 
         var message = NovelDisplayText.Build(NovelTagLexer.Parse(line.Text));
 
@@ -103,7 +108,9 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         // SEループもここで停止する
         _progress.CompleteTyping();
 
+        ShowNextIndicator();
         await WaitForAdvanceAsync();
+        HideNextIndicator();
     }
 
     public async UniTask<int> ShowChoicesAsync(IReadOnlyList<string> options, CancellationToken ct)
@@ -151,6 +158,56 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         }
 
         await _progress.WaitForNext();
+    }
+
+    private void ShowNextIndicator()
+    {
+        nextIndicator.SetActive(true);
+        PositionIndicatorAtLastCharacter();
+
+        _indicatorMotion.TryCancel();
+
+        var rt = (RectTransform)nextIndicator.transform;
+        var originalPos = rt.anchoredPosition;
+        _indicatorMotion = LMotion.Create(0f, 1f, 1f)
+            .WithLoops(-1, LoopType.Yoyo)
+            .WithEase(Ease.InOutSine)
+            .Bind(t =>
+            {
+                var pos = originalPos;
+                pos.y += Mathf.Sin(t * Mathf.PI) * 5f;
+                rt.anchoredPosition = pos;
+            })
+            .AddTo(this);
+    }
+
+    private void HideNextIndicator()
+    {
+        _indicatorMotion.TryCancel();
+        nextIndicator.SetActive(false);
+    }
+
+    // 最後の可視文字の右下に付ける。行数や文量で位置が変わるため毎回測り直す
+    private void PositionIndicatorAtLastCharacter()
+    {
+        messageLabel.ForceMeshUpdate();
+        var textInfo = messageLabel.textInfo;
+        if (textInfo.characterCount == 0) return;
+
+        var lastIndex = textInfo.characterCount - 1;
+        while (lastIndex >= 0)
+        {
+            var info = textInfo.characterInfo[lastIndex];
+            if (info.isVisible && !char.IsWhiteSpace(info.character)) break;
+            lastIndex--;
+        }
+        if (lastIndex < 0) return;
+
+        var lastChar = textInfo.characterInfo[lastIndex];
+        var worldPos = messageLabel.rectTransform.TransformPoint(new Vector3(lastChar.topRight.x, lastChar.bottomRight.y, 0f));
+        var rt = (RectTransform)nextIndicator.transform;
+        var localPos = ((RectTransform)rt.parent).InverseTransformPoint(worldPos);
+        rt.anchoredPosition = new Vector2(localPos.x + 30f, localPos.y + 5f);
     }
 
     private void SetAutoMode(bool on)

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -20,6 +20,11 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     [SerializeField] private TextMeshProUGUI messageLabel;
     [SerializeField] private RectTransform choiceContainer;
     [SerializeField] private Button choiceButtonPrefab;
+    [SerializeField] private Button autoButton;
+    [SerializeField] private TextMeshProUGUI autoButtonText;
+    [SerializeField] private Button skipButton;
+    [SerializeField] private Color autoButtonNormalColor = Color.white;
+    [SerializeField] private Color autoButtonActiveColor = Color.yellow;
     [SerializeField] private float charSpeed = 0.03f;
     [SerializeField] private float autoNextDelay = 3f;
     [SerializeField] private string typingSeName = "Dialog2";
@@ -153,9 +158,17 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         if (_isAutoMode == on) return;
 
         _isAutoMode = on;
+        autoButtonText.color = _isAutoMode ? autoButtonActiveColor : autoButtonNormalColor;
 
         // 待機中の切り替えは進行中のタイムアウトを取り消して待ち方を組み直す
         if (_progress.IsWaitingForNext) _progress.CancelWait();
+    }
+
+    private void Awake()
+    {
+        autoButton.onClick.AddListener(ToggleAutoMode);
+        skipButton.onClick.AddListener(RequestSkip);
+        autoButtonText.color = autoButtonNormalColor;
     }
 
     private void OnDestroy()

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using LitMotion;
-using LitMotion.Extensions;
 using Novel.Runtime;
+using Novel.View;
 using R3;
 using TMPro;
 using UnityEngine;
@@ -13,9 +13,9 @@ using Void2610.UnityTemplate;
 
 /// <summary>
 /// novel-kit のINovelView実装
-/// 参考実装のNovelMessageViewは文字送りと送り待ちを1つのawaitに畳んでおり、文字送り音を打ち終わりで止められないため自前で持つ
+/// 文字送りの進行はnovel-kitのTextRevealEngineに委譲し、TMPへの反映と打鍵音・インジケーターだけを持つ
 /// </summary>
-public class NovelKitMessageView : MonoBehaviour, INovelView
+public class NovelKitMessageView : MonoBehaviour, INovelView, INovelPlaybackSettings
 {
     [SerializeField] private GameObject window;
     [SerializeField] private TextMeshProUGUI nameLabel;
@@ -28,8 +28,12 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     [SerializeField] private Button skipButton;
     [SerializeField] private Color autoButtonNormalColor = Color.white;
     [SerializeField] private Color autoButtonActiveColor = Color.yellow;
-    [SerializeField] private float charSpeed = 0.03f;
-    [SerializeField] private float autoNextDelay = 3f;
+    [SerializeField] private float charsPerSecond = 33f;
+    [SerializeField] private float autoAdvanceDelay = 3f;
+    [SerializeField] private bool skipUnread = true;
+    [SerializeField] private float shakeAmplitude = 3f;
+    [SerializeField] private float waveAmplitude = 4f;
+    [SerializeField] private float waveSpeed = 6f;
     [SerializeField] private float indicatorBounceDuration = 1f;
     [SerializeField] private float indicatorBounceAmplitude = 5f;
     [SerializeField] private Vector2 indicatorOffset = new(30f, 5f);
@@ -40,16 +44,18 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     /// </summary>
     public Observable<Unit> OnSkipRequested => _onSkipRequested;
 
-    public bool IsAutoMode => _isAutoMode;
+    public bool IsAutoMode => _engine.Auto;
 
-    private readonly TextProgressController _progress = new();
+    public float CharsPerSecond => charsPerSecond;
+    public float AutoAdvanceDelay => autoAdvanceDelay;
+    public bool SkipUnread => skipUnread;
+
     private readonly Subject<Unit> _onSkipRequested = new();
 
+    private TextRevealEngine _engine;
     private MotionHandle _indicatorMotion;
-    private bool _isAutoMode;
-    private bool _isSkipMode;
 
-    public void ToggleAutoMode() => SetAutoMode(!_isAutoMode);
+    public void ToggleAutoMode() => SetAutoMode(!_engine.Auto);
 
     public void RequestSkip() => _onSkipRequested.OnNext(Unit.Default);
 
@@ -58,13 +64,13 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     public void Advance()
     {
         // オート中の送り入力はオートを解除する（意図しない自動進行を止める）
-        if (_isAutoMode && _progress.IsWaitingForNext)
+        if (_engine.Auto)
         {
             SetAutoMode(false);
             return;
         }
 
-        _progress.AdvanceToNext();
+        _engine.RequestAdvance();
     }
 
     /// <summary>
@@ -72,9 +78,8 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     /// </summary>
     public void BeginSkip()
     {
-        _isSkipMode = true;
         SetAutoMode(false);
-        _progress.ForceComplete();
+        _engine.Skip = true;
     }
 
     public async UniTask ShowMessageAsync(NovelLine line, CancellationToken ct)
@@ -83,43 +88,41 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         nameLabel.text = line.DisplayName ?? "";
         HideNextIndicator();
 
-        var message = NovelDisplayText.Build(NovelTagLexer.Parse(line.Text));
+        var tokens = NovelTagLexer.Parse(line.Text);
+        _engine.Build(tokens);
 
-        if (_isSkipMode)
-        {
-            // 全文を即座に出し、待たずに次へ（1フレームだけ送って表示を反映させる）
-            messageLabel.text = message;
-            messageLabel.maxVisibleCharacters = int.MaxValue;
-            await UniTask.NextFrame(ct);
-            return;
-        }
+        messageLabel.text = NovelDisplayText.Build(tokens);
+        messageLabel.ForceMeshUpdate();
+        var tmpTotal = messageLabel.textInfo.characterCount;
+        messageLabel.maxVisibleCharacters = 0;
 
-        var typingToken = _progress.BeginTyping();
-
-        SeManager.Instance.PlaySeLoop(typingSeName, cancellationToken: _progress.DialogSeToken).Forget();
+        using var animCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var anim = AnimateEffectsAsync(animCts.Token).SuppressCancellationThrow();
+        var seCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        SeManager.Instance.PlaySeLoop(typingSeName, cancellationToken: seCts.Token).Forget();
 
         try
         {
-            await messageLabel.RichTextTypewriterAnimation(message, charSpeed, typingToken);
+            await _engine.RevealOnlyAsync(line.IsAlreadyRead,
+                v => messageLabel.maxVisibleCharacters = Mathf.Min(v, tmpTotal), ct);
         }
-        catch (OperationCanceledException)
+        finally
         {
-            // 文字送り中の送り入力でキャンセルされた場合は全文を即座に表示
-            messageLabel.maxVisibleCharacters = int.MaxValue;
+            // 打鍵音は送り待ちに入る前に止める
+            seCts.Cancel();
+            seCts.Dispose();
+            animCts.Cancel();
         }
-
-        // SEループもここで停止する
-        _progress.CompleteTyping();
 
         ShowNextIndicator();
-        await WaitForAdvanceAsync();
+        await _engine.WaitForAdvanceAsync(line.IsAlreadyRead, ct);
         HideNextIndicator();
     }
 
     public async UniTask<int> ShowChoicesAsync(IReadOnlyList<string> options, CancellationToken ct)
     {
         // 選択肢はプレイヤーの判断が要るのでスキップを打ち切る
-        _isSkipMode = false;
+        _engine.Skip = false;
 
         var tcs = new UniTaskCompletionSource<int>();
         var spawned = new List<GameObject>(options.Count);
@@ -151,14 +154,47 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         messageLabel.text = "";
     }
 
-    // オート中は一定時間で自動送り。待機中に解除されたら手動待ちへ落とす
-    private async UniTask WaitForAdvanceAsync()
+    // shake/wave の頂点アニメ。区間はエンジンが可視index単位で算出済み
+    private async UniTask AnimateEffectsAsync(CancellationToken ct)
     {
-        // オート切替は待機をキャンセルして戻ってくるだけなので、進行が確定するまで待ち方を選び直す
-        while (_progress.IsWaitingForNext)
+        var shake = _engine.ShakeSpans;
+        var wave = _engine.WaveSpans;
+        if (shake.Count == 0 && wave.Count == 0) return;
+
+        while (!ct.IsCancellationRequested)
         {
-            if (_isAutoMode) await _progress.WaitForNextWithTimeout(autoNextDelay);
-            else await _progress.WaitForNext();
+            messageLabel.ForceMeshUpdate();
+            var info = messageLabel.textInfo;
+            var visible = messageLabel.maxVisibleCharacters;
+
+            ApplyOffset(info, shake, visible, isWave: false);
+            ApplyOffset(info, wave, visible, isWave: true);
+
+            for (var m = 0; m < info.meshInfo.Length; m++)
+                messageLabel.UpdateGeometry(info.meshInfo[m].mesh, m);
+
+            await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, ct);
+        }
+    }
+
+    private void ApplyOffset(TMP_TextInfo info, IReadOnlyList<(int start, int end)> ranges, int visible, bool isWave)
+    {
+        foreach (var (start, end) in ranges)
+        {
+            for (var i = start; i < end && i < visible && i < info.characterCount; i++)
+            {
+                var ch = info.characterInfo[i];
+                if (!ch.isVisible) continue;
+
+                var offset = isWave
+                    ? new Vector3(0f, Mathf.Sin(Time.time * waveSpeed + i * 0.5f) * waveAmplitude, 0f)
+                    : new Vector3(UnityEngine.Random.Range(-shakeAmplitude, shakeAmplitude),
+                        UnityEngine.Random.Range(-shakeAmplitude, shakeAmplitude), 0f);
+
+                var verts = info.meshInfo[ch.materialReferenceIndex].vertices;
+                var vi = ch.vertexIndex;
+                for (var k = 0; k < 4; k++) verts[vi + k] += offset;
+            }
         }
     }
 
@@ -214,17 +250,13 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
 
     private void SetAutoMode(bool on)
     {
-        if (_isAutoMode == on) return;
-
-        _isAutoMode = on;
-        autoButtonText.color = _isAutoMode ? autoButtonActiveColor : autoButtonNormalColor;
-
-        // 待機中の切り替えは進行中のタイムアウトを取り消して待ち方を組み直す
-        if (_progress.IsWaitingForNext) _progress.CancelWait();
+        _engine.Auto = on;
+        autoButtonText.color = on ? autoButtonActiveColor : autoButtonNormalColor;
     }
 
     private void Awake()
     {
+        _engine = new TextRevealEngine(this, new UnityFrameClock());
         autoButton.onClick.AddListener(ToggleAutoMode);
         skipButton.onClick.AddListener(RequestSkip);
         autoButtonText.color = autoButtonNormalColor;
@@ -232,7 +264,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
 
     private void OnDestroy()
     {
+        _indicatorMotion.TryCancel();
         _onSkipRequested.Dispose();
-        _progress.Dispose();
     }
 }

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using Novel.Runtime;
+using R3;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -20,13 +21,49 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     [SerializeField] private RectTransform choiceContainer;
     [SerializeField] private Button choiceButtonPrefab;
     [SerializeField] private float charSpeed = 0.03f;
+    [SerializeField] private float autoNextDelay = 3f;
     [SerializeField] private string typingSeName = "Dialog2";
 
-    private readonly TextProgressController _progress = new();
+    /// <summary>
+    /// スキップが要求された（確認ダイアログは購読側が担当する）
+    /// </summary>
+    public Observable<Unit> OnSkipRequested => _onSkipRequested;
 
-    public void Advance() => _progress.AdvanceToNext();
+    public bool IsAutoMode => _isAutoMode;
+
+    private readonly TextProgressController _progress = new();
+    private readonly Subject<Unit> _onSkipRequested = new();
+
+    private bool _isAutoMode;
+    private bool _isSkipMode;
+
+    public void ToggleAutoMode() => SetAutoMode(!_isAutoMode);
+
+    public void RequestSkip() => _onSkipRequested.OnNext(Unit.Default);
 
     public void SetMessageWindowVisible(bool visible) => window.SetActive(visible);
+
+    public void Advance()
+    {
+        // オート中の送り入力はオートを解除する（意図しない自動進行を止める）
+        if (_isAutoMode && _progress.IsWaitingForNext)
+        {
+            SetAutoMode(false);
+            return;
+        }
+
+        _progress.AdvanceToNext();
+    }
+
+    /// <summary>
+    /// 選択肢に当たるまで送りを飛ばす
+    /// </summary>
+    public void BeginSkip()
+    {
+        _isSkipMode = true;
+        SetAutoMode(false);
+        _progress.ForceComplete();
+    }
 
     public async UniTask ShowMessageAsync(NovelLine line, CancellationToken ct)
     {
@@ -34,6 +71,16 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         nameLabel.text = line.DisplayName ?? "";
 
         var message = NovelDisplayText.Build(NovelTagLexer.Parse(line.Text));
+
+        if (_isSkipMode)
+        {
+            // 全文を即座に出し、待たずに次へ（1フレームだけ送って表示を反映させる）
+            messageLabel.text = message;
+            messageLabel.maxVisibleCharacters = int.MaxValue;
+            await UniTask.NextFrame(ct);
+            return;
+        }
+
         var typingToken = _progress.BeginTyping();
 
         SeManager.Instance.PlaySeLoop(typingSeName, cancellationToken: _progress.DialogSeToken).Forget();
@@ -51,11 +98,14 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         // SEループもここで停止する
         _progress.CompleteTyping();
 
-        await _progress.WaitForNext();
+        await WaitForAdvanceAsync();
     }
 
     public async UniTask<int> ShowChoicesAsync(IReadOnlyList<string> options, CancellationToken ct)
     {
+        // 選択肢はプレイヤーの判断が要るのでスキップを打ち切る
+        _isSkipMode = false;
+
         var tcs = new UniTaskCompletionSource<int>();
         var spawned = new List<GameObject>(options.Count);
 
@@ -86,8 +136,31 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         messageLabel.text = "";
     }
 
+    // オート中は一定時間で自動送り。待機中に解除されたら手動待ちへ落とす
+    private async UniTask WaitForAdvanceAsync()
+    {
+        while (_isAutoMode)
+        {
+            await _progress.WaitForNextWithTimeout(autoNextDelay);
+            if (!_progress.IsWaitingForNext) return;
+        }
+
+        await _progress.WaitForNext();
+    }
+
+    private void SetAutoMode(bool on)
+    {
+        if (_isAutoMode == on) return;
+
+        _isAutoMode = on;
+
+        // 待機中の切り替えは進行中のタイムアウトを取り消して待ち方を組み直す
+        if (_progress.IsWaitingForNext) _progress.CancelWait();
+    }
+
     private void OnDestroy()
     {
+        _onSkipRequested.Dispose();
         _progress.Dispose();
     }
 }

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -30,6 +30,9 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     [SerializeField] private Color autoButtonActiveColor = Color.yellow;
     [SerializeField] private float charSpeed = 0.03f;
     [SerializeField] private float autoNextDelay = 3f;
+    [SerializeField] private float indicatorBounceDuration = 1f;
+    [SerializeField] private float indicatorBounceAmplitude = 5f;
+    [SerializeField] private Vector2 indicatorOffset = new(30f, 5f);
     [SerializeField] private string typingSeName = "Dialog2";
 
     /// <summary>
@@ -151,13 +154,12 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     // オート中は一定時間で自動送り。待機中に解除されたら手動待ちへ落とす
     private async UniTask WaitForAdvanceAsync()
     {
-        while (_isAutoMode)
+        // オート切替は待機をキャンセルして戻ってくるだけなので、進行が確定するまで待ち方を選び直す
+        while (_progress.IsWaitingForNext)
         {
-            await _progress.WaitForNextWithTimeout(autoNextDelay);
-            if (!_progress.IsWaitingForNext) return;
+            if (_isAutoMode) await _progress.WaitForNextWithTimeout(autoNextDelay);
+            else await _progress.WaitForNext();
         }
-
-        await _progress.WaitForNext();
     }
 
     private void ShowNextIndicator()
@@ -169,13 +171,13 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
 
         var rt = (RectTransform)nextIndicator.transform;
         var originalPos = rt.anchoredPosition;
-        _indicatorMotion = LMotion.Create(0f, 1f, 1f)
+        _indicatorMotion = LMotion.Create(0f, 1f, indicatorBounceDuration)
             .WithLoops(-1, LoopType.Yoyo)
             .WithEase(Ease.InOutSine)
             .Bind(t =>
             {
                 var pos = originalPos;
-                pos.y += Mathf.Sin(t * Mathf.PI) * 5f;
+                pos.y += Mathf.Sin(t * Mathf.PI) * indicatorBounceAmplitude;
                 rt.anchoredPosition = pos;
             })
             .AddTo(this);
@@ -207,7 +209,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         var worldPos = messageLabel.rectTransform.TransformPoint(new Vector3(lastChar.topRight.x, lastChar.bottomRight.y, 0f));
         var rt = (RectTransform)nextIndicator.transform;
         var localPos = ((RectTransform)rt.parent).InverseTransformPoint(worldPos);
-        rt.anchoredPosition = new Vector2(localPos.x + 30f, localPos.y + 5f);
+        rt.anchoredPosition = new Vector2(localPos.x, localPos.y) + indicatorOffset;
     }
 
     private void SetAutoMode(bool on)

--- a/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
@@ -8,10 +8,10 @@ using UnityEngine;
 using Void2610.UnityTemplate;
 
 /// <summary>
-/// novel-kit のIPortraitView実装
+/// novel-kit のIPortraitChannel実装
 /// レイアウト別のスロット座標へ立ち絵を配置し、表示・退場を行う
 /// </summary>
-public class NovelKitPortraitView : MonoBehaviour, IPortraitView
+public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel
 {
     [Serializable]
     private struct Slot
@@ -40,14 +40,14 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitView
         return UniTask.CompletedTask;
     }
 
-    public async UniTask ShowAsync(int slotIndex, string character, ResolvedSprite portrait, CancellationToken ct)
+    public async UniTask ShowAsync(int slotIndex, ResolvedSprite portrait, CancellationToken ct)
     {
         if (!IsValidSlot(slotIndex)) return;
         if (!portrait.IsLoaded)
         {
             // 消去指示 (空キー) は退場として扱い、ロード失敗だけ警告する
             if (portrait.IsCleared) await HideAsync(slotIndex, ct);
-            else Debug.LogWarning($"[NovelKitPortraitView] 立ち絵の解決に失敗: {character} ({portrait.Key})");
+            else Debug.LogWarning($"[NovelKitPortraitView] 立ち絵の解決に失敗: {portrait.Key}");
             return;
         }
 

--- a/Assets/Scripts/UI/Views/TextProgressController.cs
+++ b/Assets/Scripts/UI/Views/TextProgressController.cs
@@ -24,6 +24,12 @@ public class TextProgressController
     private bool _isWaitingForNext;
 
     /// <summary>
+    /// 待機だけを打ち切る（進行はさせない）
+    /// オート解除時に自動進行のタイムアウトを取り消し、手動待ちへ落とすために使う
+    /// </summary>
+    public void CancelWait() => _waitCancellationTokenSource?.Cancel();
+
+    /// <summary>
     /// タイピングを開始し、キャンセルトークンを返す
     /// </summary>
     public CancellationToken BeginTyping()
@@ -129,12 +135,6 @@ public class TextProgressController
         // 次へ進む
         _isWaitingForNext = false;
     }
-
-    /// <summary>
-    /// 待機だけを打ち切る（進行はさせない）
-    /// オート解除時に自動進行のタイムアウトを取り消し、手動待ちへ落とすために使う
-    /// </summary>
-    public void CancelWait() => _waitCancellationTokenSource?.Cancel();
 
     /// <summary>
     /// 文字送りも待機も打ち切って完了扱いにする（スキップ用）

--- a/Assets/Scripts/UI/Views/TextProgressController.cs
+++ b/Assets/Scripts/UI/Views/TextProgressController.cs
@@ -12,6 +12,11 @@ public class TextProgressController
     /// </summary>
     public CancellationToken DialogSeToken => _dialogSeCancellationTokenSource?.Token ?? CancellationToken.None;
 
+    /// <summary>
+    /// 送り待ち中かどうか
+    /// </summary>
+    public bool IsWaitingForNext => _isWaitingForNext;
+
     private CancellationTokenSource _typingCancellationTokenSource;
     private CancellationTokenSource _dialogSeCancellationTokenSource;
     private CancellationTokenSource _waitCancellationTokenSource;
@@ -122,6 +127,23 @@ public class TextProgressController
         _waitCancellationTokenSource?.Cancel();
 
         // 次へ進む
+        _isWaitingForNext = false;
+    }
+
+    /// <summary>
+    /// 待機だけを打ち切る（進行はさせない）
+    /// オート解除時に自動進行のタイムアウトを取り消し、手動待ちへ落とすために使う
+    /// </summary>
+    public void CancelWait() => _waitCancellationTokenSource?.Cancel();
+
+    /// <summary>
+    /// 文字送りも待機も打ち切って完了扱いにする（スキップ用）
+    /// </summary>
+    public void ForceComplete()
+    {
+        SkipTyping();
+
+        _waitCancellationTokenSource?.Cancel();
         _isWaitingForNext = false;
     }
 

--- a/Assets/Scripts/UI/Views/TextProgressController.cs
+++ b/Assets/Scripts/UI/Views/TextProgressController.cs
@@ -12,22 +12,11 @@ public class TextProgressController
     /// </summary>
     public CancellationToken DialogSeToken => _dialogSeCancellationTokenSource?.Token ?? CancellationToken.None;
 
-    /// <summary>
-    /// 送り待ち中かどうか
-    /// </summary>
-    public bool IsWaitingForNext => _isWaitingForNext;
-
     private CancellationTokenSource _typingCancellationTokenSource;
     private CancellationTokenSource _dialogSeCancellationTokenSource;
     private CancellationTokenSource _waitCancellationTokenSource;
     private bool _isTyping;
     private bool _isWaitingForNext;
-
-    /// <summary>
-    /// 待機だけを打ち切る（進行はさせない）
-    /// オート解除時に自動進行のタイムアウトを取り消し、手動待ちへ落とすために使う
-    /// </summary>
-    public void CancelWait() => _waitCancellationTokenSource?.Cancel();
 
     /// <summary>
     /// タイピングを開始し、キャンセルトークンを返す
@@ -133,17 +122,6 @@ public class TextProgressController
         _waitCancellationTokenSource?.Cancel();
 
         // 次へ進む
-        _isWaitingForNext = false;
-    }
-
-    /// <summary>
-    /// 文字送りも待機も打ち切って完了扱いにする（スキップ用）
-    /// </summary>
-    public void ForceComplete()
-    {
-        SkipTyping();
-
-        _waitCancellationTokenSource?.Cancel();
         _isWaitingForNext = false;
     }
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -22,7 +22,7 @@
     "com.unity.visualeffectgraph": "17.3.0",
     "com.unity.visualscripting": "1.9.9",
     "com.unityroom.client": "https://github.com/naichilab/unityroom-client-library.git?path=Assets/unityroom",
-    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#1dd19601caf55cc07f543e44fce7e69354ceaf54",
+    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#0f7da75ddfd6f1e04d49482c8aaa2412a44da52a",
     "com.void2610.unity-template": "https://github.com/void2610/my-unity-template.git",
     "com.yujiap.unity-toolbar-extension": "https://github.com/void2610/UnityToolbarExtension.git",
     "io.github.hatayama.uloopmcp": "https://github.com/hatayama/uLoopMCP.git?path=/Packages/src",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -450,13 +450,13 @@
       "hash": "c4dea57e1c27567bac512e090a356b08abf83d0b"
     },
     "com.void2610.novel-kit": {
-      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#1dd19601caf55cc07f543e44fce7e69354ceaf54",
+      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#0f7da75ddfd6f1e04d49482c8aaa2412a44da52a",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.ugui": "2.0.0"
       },
-      "hash": "1dd19601caf55cc07f543e44fce7e69354ceaf54"
+      "hash": "0f7da75ddfd6f1e04d49482c8aaa2412a44da52a"
     },
     "com.void2610.unity-template": {
       "version": "https://github.com/void2610/my-unity-template.git",


### PR DESCRIPTION
## 概要

novel-kit へ移行したノベルに、旧実装が持っていた操作と表示が揃っていなかったため。

## 変更点

- オートとスキップを追加。挙動・待ち時間・確認ダイアログの文言は旧 `DialogView` を踏襲し、スキップは選択肢に当たると自動で解除される
- 操作ボタンを共通ボタンプレハブ (`Assets/Prefabs/Button/TextButton.prefab`) のネストインスタンスとして配置
- 送り待ちのインジケーターを追加。最後の可視文字の右下に置き、上下に揺れる
- 背景まわりを黒基調に統一。未設定の Image が白く出ていたものを透過にし、フェードの谷で覗くカメラのクリア色も黒にした
- 文字送り・SE・送り待ちの状態管理は既存の `TextProgressController` を再利用し、不足していた口だけ追加

## 動作確認

- [x] オート ON で入力なしに進行し、送り入力またはボタン再押下で解除される
- [x] スキップが選択肢で停止し、確認ダイアログを経て開始される
- [x] インジケーターが文字送り中は出ず、送り待ちの間だけ表示される
- [x] 背景が未設定でも白く出ない