### PR TITLE
fix: NovelKitScene の背景を黒基調にする

### DIFF
--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -60,7 +60,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -710,8 +710,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -655, y: 137}
-  m_SizeDelta: {x: 420, y: 62}
+  m_AnchoredPosition: {x: -550, y: 137}
+  m_SizeDelta: {x: 330, y: 55}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4359840747759146873
 CanvasRenderer:
@@ -847,8 +847,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 30, y: -45}
-  m_SizeDelta: {x: 1450, y: 200}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 1350, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6513097489142510738
 CanvasRenderer:
@@ -905,8 +905,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 30
-  m_fontSizeBase: 30
+  m_fontSize: 40
+  m_fontSizeBase: 40
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -959,8 +959,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7376430804190998633}
-  - component: {fileID: 5428266411713009942}
   - component: {fileID: 6304849522132463678}
+  - component: {fileID: 6903809405870213346}
   m_Layer: 0
   m_Name: NovelKitView
   m_TagString: Untagged
@@ -992,26 +992,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &5428266411713009942
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7207363111601382205}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a5e892d2738544a77a56608892a39d82, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Novel.View::Novel.View.NovelMessageView
-  window: {fileID: 349495271076974098}
-  nameLabel: {fileID: 7172017768859041692}
-  messageLabel: {fileID: 2868043861240887093}
-  shakeAmplitude: 3
-  waveAmplitude: 4
-  waveSpeed: 6
-  choiceContainer: {fileID: 4554064236941310087}
-  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
 --- !u!114 &6304849522132463678
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1025,6 +1005,25 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitAudioChannel
   seManager: {fileID: 599100507661183887}
+--- !u!114 &6903809405870213346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7207363111601382205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23b33c23aa16e477f812dda1afa3d2f4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NovelKitMessageView
+  window: {fileID: 349495271076974098}
+  nameLabel: {fileID: 7172017768859041692}
+  messageLabel: {fileID: 2868043861240887093}
+  choiceContainer: {fileID: 4554064236941310087}
+  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
+  charSpeed: 0.03
+  typingSeName: Dialog2
 --- !u!1 &9150722108618635631
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NovelKitScene.unity
+++ b/Assets/Scenes/NovelKitScene.unity
@@ -153,7 +153,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -469,6 +469,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 935884767}
     m_Modifications:
+    - target: {fileID: 9100013, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
       propertyPath: m_Name
       value: NovelView
@@ -649,7 +653,7 @@ MonoBehaviour:
   messageLabel: {fileID: 7979043816502831970}
   choiceContainer: {fileID: 7979043816502831969}
   choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
-  charsPerSecond: 40
+  charSpeed: 0.03
   typingSeName: Dialog2
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Assets/Scenes/NovelKitScene.unity
+++ b/Assets/Scenes/NovelKitScene.unity
@@ -469,10 +469,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 935884767}
     m_Modifications:
-    - target: {fileID: 9100013, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-      propertyPath: m_Color.a
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
       propertyPath: m_Name
       value: NovelView
@@ -557,14 +553,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 5428266411713009942, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7979043816502831974}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
 --- !u!114 &7979043816502831966 stripped
 MonoBehaviour:
@@ -593,68 +585,23 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6304849522132463678, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
   m_PrefabInstance: {fileID: 7979043816502831965}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7979043816502831973}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 09b24bd844c34050badec050a89104b8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitAudioChannel
---- !u!224 &7979043816502831969 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4554064236941310087, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &7979043816502831970 stripped
+--- !u!114 &7979043816502831974 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2868043861240887093, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
+  m_CorrespondingSourceObject: {fileID: 6903809405870213346, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
   m_PrefabInstance: {fileID: 7979043816502831965}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
---- !u!114 &7979043816502831971 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7172017768859041692, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
---- !u!1 &7979043816502831972 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 349495271076974098, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &7979043816502831973 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7207363111601382205, guid: ef8970a3ec7604638bb27a6c06e9f674, type: 3}
-  m_PrefabInstance: {fileID: 7979043816502831965}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &7979043816502831974
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7979043816502831973}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 23b33c23aa16e477f812dda1afa3d2f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitMessageView
-  window: {fileID: 7979043816502831972}
-  nameLabel: {fileID: 7979043816502831971}
-  messageLabel: {fileID: 7979043816502831970}
-  choiceContainer: {fileID: 7979043816502831969}
-  choiceButtonPrefab: {fileID: 5645178109978945894, guid: 24fba00ae0842054b8ba929624c57e8e, type: 3}
-  charSpeed: 0.03
-  typingSeName: Dialog2
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 概要

未設定の Image がそのまま白く描かれており、背景の切り替え時に不自然だったため。

## 変更点

- 背景の Image を透過にした。旧 `DialogBackgroundView` が背景未設定時に `Color.clear` にしているのと揃えた
- カメラのクリア色を不透明の黒にした。背景の切り替えは同じ Image を alpha 0 まで落とすため、フェードの谷でクリア色が覗く

なお白背景は旧ノベルでも使われていない (Excel 全シートの背景指定は `Lobby` と `LobbyDark` のみ、白の素材も存在しない)。

## 動作確認

- [x] 「sprite 未設定なのに不透明」なフレームが 0 件であることを再生して確認