### PR TITLE
fix: ノベルの送り待ちとスキップ確認の不具合を直す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ tools/**/obj/
 !/Assets/Packages/com.discord.partnersdk.meta
 # System.CodeDom は Editor 除外の手動設定を持つため dll の meta のみ追跡 (Unity 標準 System との CS0433 回避)
 !/Assets/Packages/System.CodeDom.*/**/*.dll.meta
+outputs/

--- a/Assets/Scripts/NovelKit/NovelKitAdvanceInput.cs
+++ b/Assets/Scripts/NovelKit/NovelKitAdvanceInput.cs
@@ -1,6 +1,7 @@
 using System;
 using Cysharp.Threading.Tasks;
 using R3;
+using UnityEngine;
 using VContainer.Unity;
 using Void2610.SettingsSystem;
 using Void2610.UnityTemplate;
@@ -15,6 +16,8 @@ public class NovelKitAdvanceInput : IStartable, IDisposable
     private readonly IConfirmationDialog _confirmationDialog;
     private readonly CompositeDisposable _disposables = new();
 
+    private bool _isConfirming;
+
     public NovelKitAdvanceInput(NovelKitMessageView view, InputActionsProvider inputActionsProvider,
         IConfirmationDialog confirmationDialog)
     {
@@ -23,12 +26,21 @@ public class NovelKitAdvanceInput : IStartable, IDisposable
         _confirmationDialog = confirmationDialog;
     }
 
-    private async UniTaskVoid ConfirmAndSkip()
+    // ボタンとキーの両方から要求が来るため、確認中の再要求は捨てる
+    private async UniTask ConfirmAndSkip()
     {
-        var confirmed = await _confirmationDialog.ShowDialog("現在のシナリオをスキップしますか？", "スキップ", "キャンセル");
-        if (!confirmed) return;
+        if (_isConfirming) return;
 
-        _view.BeginSkip();
+        _isConfirming = true;
+        try
+        {
+            var confirmed = await _confirmationDialog.ShowDialog("現在のシナリオをスキップしますか？", "スキップ", "キャンセル");
+            if (confirmed) _view.BeginSkip();
+        }
+        finally
+        {
+            _isConfirming = false;
+        }
     }
 
     public void Start()
@@ -49,7 +61,7 @@ public class NovelKitAdvanceInput : IStartable, IDisposable
             .AddTo(_disposables);
 
         _view.OnSkipRequested
-            .Subscribe(_ => ConfirmAndSkip().Forget())
+            .Subscribe(_ => ConfirmAndSkip().Forget(Debug.LogException))
             .AddTo(_disposables);
     }
 

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -30,6 +30,9 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     [SerializeField] private Color autoButtonActiveColor = Color.yellow;
     [SerializeField] private float charSpeed = 0.03f;
     [SerializeField] private float autoNextDelay = 3f;
+    [SerializeField] private float indicatorBounceDuration = 1f;
+    [SerializeField] private float indicatorBounceAmplitude = 5f;
+    [SerializeField] private Vector2 indicatorOffset = new(30f, 5f);
     [SerializeField] private string typingSeName = "Dialog2";
 
     /// <summary>
@@ -151,13 +154,12 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     // オート中は一定時間で自動送り。待機中に解除されたら手動待ちへ落とす
     private async UniTask WaitForAdvanceAsync()
     {
-        while (_isAutoMode)
+        // オート切替は待機をキャンセルして戻ってくるだけなので、進行が確定するまで待ち方を選び直す
+        while (_progress.IsWaitingForNext)
         {
-            await _progress.WaitForNextWithTimeout(autoNextDelay);
-            if (!_progress.IsWaitingForNext) return;
+            if (_isAutoMode) await _progress.WaitForNextWithTimeout(autoNextDelay);
+            else await _progress.WaitForNext();
         }
-
-        await _progress.WaitForNext();
     }
 
     private void ShowNextIndicator()
@@ -169,13 +171,13 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
 
         var rt = (RectTransform)nextIndicator.transform;
         var originalPos = rt.anchoredPosition;
-        _indicatorMotion = LMotion.Create(0f, 1f, 1f)
+        _indicatorMotion = LMotion.Create(0f, 1f, indicatorBounceDuration)
             .WithLoops(-1, LoopType.Yoyo)
             .WithEase(Ease.InOutSine)
             .Bind(t =>
             {
                 var pos = originalPos;
-                pos.y += Mathf.Sin(t * Mathf.PI) * 5f;
+                pos.y += Mathf.Sin(t * Mathf.PI) * indicatorBounceAmplitude;
                 rt.anchoredPosition = pos;
             })
             .AddTo(this);
@@ -207,7 +209,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         var worldPos = messageLabel.rectTransform.TransformPoint(new Vector3(lastChar.topRight.x, lastChar.bottomRight.y, 0f));
         var rt = (RectTransform)nextIndicator.transform;
         var localPos = ((RectTransform)rt.parent).InverseTransformPoint(worldPos);
-        rt.anchoredPosition = new Vector2(localPos.x + 30f, localPos.y + 5f);
+        rt.anchoredPosition = new Vector2(localPos.x, localPos.y) + indicatorOffset;
     }
 
     private void SetAutoMode(bool on)


### PR DESCRIPTION
## 概要

Copilot レビューの指摘対応。指摘そのものは成立しなかったが、調べる過程で送り待ちの実バグが見つかったため。

> stacked PR: base は #211

## 変更点

- 送り待ちを「進行が確定するまで待ち方を選び直す」ループにした。手動待ち中にオートを入れると 1 行飛ぶことがあり、タイミング依存で挙動が割れていた
- スキップ確認の再入を抑止した。ボタンとキーの両方から要求が来るため
- `Forget` に例外ハンドラを付けた
- インジケーターの周期・振幅・オフセットを SerializeField 化した

## 動作確認

- [x] 手動待ち中にオート ON → 3.30 秒後に進行 (修正前はタイミングにより即進行)
- [x] オート待ち中にオート OFF → 10 秒放置で進まない