### PR TITLE
refac: ノベルの文字送りを novel-kit のエンジンに一本化する

### DIFF
--- a/Assets/ScriptableObjects/ExhibitSettings.asset
+++ b/Assets/ScriptableObjects/ExhibitSettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eee8e9a6df8ed40f7adc2357ab11e98e, type: 3}
   m_Name: ExhibitSettings
   m_EditorClassIdentifier: 
-  enableExhibitMode: 1
+  enableExhibitMode: 0
   idleReturnSceneName: TitleScene
   sessionLimitSceneName: ThanksScene
   idleSkipSceneNames:

--- a/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
@@ -4,7 +4,7 @@ using Novel.Assets;
 using UnityEngine;
 
 /// <summary>
-/// novel-kit のIBackgroundView実装
+/// novel-kit のIBackgroundChannel / IStillChannel実装
 /// 既存のDialogBackgroundView (黒経由フェード) へ委譲する。イベントCGも同じ全画面レイヤーで出す
 /// </summary>
 public class NovelKitBackgroundView : MonoBehaviour, IBackgroundChannel, IStillChannel

--- a/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitBackgroundView.cs
@@ -5,14 +5,11 @@ using UnityEngine;
 
 /// <summary>
 /// novel-kit のIBackgroundView実装
-/// 既存のDialogBackgroundView (黒経由フェード) へ委譲する
+/// 既存のDialogBackgroundView (黒経由フェード) へ委譲する。イベントCGも同じ全画面レイヤーで出す
 /// </summary>
-public class NovelKitBackgroundView : MonoBehaviour, IBackgroundView
+public class NovelKitBackgroundView : MonoBehaviour, IBackgroundChannel, IStillChannel
 {
     [SerializeField] private DialogBackgroundView backgroundView;
-
-    // イベントCGも背景と同じ全画面レイヤーで表示する (専用素材が増えたら分離する)
-    public UniTask ShowStillAsync(ResolvedSprite still, CancellationToken ct) => ShowAsync(still, ct);
 
     public async UniTask ShowAsync(ResolvedSprite background, CancellationToken ct)
     {

--- a/Assets/Scripts/NovelKit/NovelKitLifetimeScope.cs
+++ b/Assets/Scripts/NovelKit/NovelKitLifetimeScope.cs
@@ -32,8 +32,8 @@ public class NovelKitLifetimeScope : LifetimeScope
 
         // novel-kit の既定 (Resourcesロード + 警告用no-op表示) を後勝ちで上書きする
         builder.RegisterInstance<ISpriteLoader>(new AddressablesSpriteLoader(SPRITE_ADDRESS_ROOT));
-        builder.RegisterComponent(portraitView).As<IPortraitView>();
-        builder.RegisterComponent(backgroundView).As<IBackgroundView>();
+        builder.RegisterComponent(portraitView).As<IPortraitChannel>();
+        builder.RegisterComponent(backgroundView).As<IBackgroundChannel>().As<IStillChannel>();
         builder.RegisterComponent(audioChannel).As<IAudioChannel>();
 
         builder.RegisterInstance<ICharacterCatalog>(catalog);

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -54,6 +54,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView, INovelPlaybackSett
 
     private TextRevealEngine _engine;
     private MotionHandle _indicatorMotion;
+    private bool _isWaitingForAdvance;
 
     public void ToggleAutoMode() => SetAutoMode(!_engine.Auto);
 
@@ -63,8 +64,8 @@ public class NovelKitMessageView : MonoBehaviour, INovelView, INovelPlaybackSett
 
     public void Advance()
     {
-        // オート中の送り入力はオートを解除する（意図しない自動進行を止める）
-        if (_engine.Auto)
+        // 送り待ち中のオート解除だけを横取りする。文字送り中は全文表示の要求として通す
+        if (_engine.Auto && _isWaitingForAdvance)
         {
             SetAutoMode(false);
             return;
@@ -114,9 +115,19 @@ public class NovelKitMessageView : MonoBehaviour, INovelView, INovelPlaybackSett
             animCts.Cancel();
         }
 
+        await anim;   // 演出側の例外をここで回収する
+
         ShowNextIndicator();
-        await _engine.WaitForAdvanceAsync(line.IsAlreadyRead, ct);
-        HideNextIndicator();
+        _isWaitingForAdvance = true;
+        try
+        {
+            await _engine.WaitForAdvanceAsync(line.IsAlreadyRead, ct);
+        }
+        finally
+        {
+            _isWaitingForAdvance = false;
+            HideNextIndicator();
+        }
     }
 
     public async UniTask<int> ShowChoicesAsync(IReadOnlyList<string> options, CancellationToken ct)
@@ -171,7 +182,9 @@ public class NovelKitMessageView : MonoBehaviour, INovelView, INovelPlaybackSett
             ApplyOffset(info, wave, visible, isWave: true);
 
             for (var m = 0; m < info.meshInfo.Length; m++)
+            {
                 messageLabel.UpdateGeometry(info.meshInfo[m].mesh, m);
+            }
 
             await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, ct);
         }

--- a/Assets/Scripts/NovelKit/NovelKitMessageView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitMessageView.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using LitMotion;
-using LitMotion.Extensions;
 using Novel.Runtime;
+using Novel.View;
 using R3;
 using TMPro;
 using UnityEngine;
@@ -13,9 +13,9 @@ using Void2610.UnityTemplate;
 
 /// <summary>
 /// novel-kit のINovelView実装
-/// 参考実装のNovelMessageViewは文字送りと送り待ちを1つのawaitに畳んでおり、文字送り音を打ち終わりで止められないため自前で持つ
+/// 文字送りの進行はnovel-kitのTextRevealEngineに委譲し、TMPへの反映と打鍵音・インジケーターだけを持つ
 /// </summary>
-public class NovelKitMessageView : MonoBehaviour, INovelView
+public class NovelKitMessageView : MonoBehaviour, INovelView, INovelPlaybackSettings
 {
     [SerializeField] private GameObject window;
     [SerializeField] private TextMeshProUGUI nameLabel;
@@ -28,8 +28,12 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     [SerializeField] private Button skipButton;
     [SerializeField] private Color autoButtonNormalColor = Color.white;
     [SerializeField] private Color autoButtonActiveColor = Color.yellow;
-    [SerializeField] private float charSpeed = 0.03f;
-    [SerializeField] private float autoNextDelay = 3f;
+    [SerializeField] private float charsPerSecond = 33f;
+    [SerializeField] private float autoAdvanceDelay = 3f;
+    [SerializeField] private bool skipUnread = true;
+    [SerializeField] private float shakeAmplitude = 3f;
+    [SerializeField] private float waveAmplitude = 4f;
+    [SerializeField] private float waveSpeed = 6f;
     [SerializeField] private float indicatorBounceDuration = 1f;
     [SerializeField] private float indicatorBounceAmplitude = 5f;
     [SerializeField] private Vector2 indicatorOffset = new(30f, 5f);
@@ -40,16 +44,18 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     /// </summary>
     public Observable<Unit> OnSkipRequested => _onSkipRequested;
 
-    public bool IsAutoMode => _isAutoMode;
+    public bool IsAutoMode => _engine.Auto;
 
-    private readonly TextProgressController _progress = new();
+    public float CharsPerSecond => charsPerSecond;
+    public float AutoAdvanceDelay => autoAdvanceDelay;
+    public bool SkipUnread => skipUnread;
+
     private readonly Subject<Unit> _onSkipRequested = new();
 
+    private TextRevealEngine _engine;
     private MotionHandle _indicatorMotion;
-    private bool _isAutoMode;
-    private bool _isSkipMode;
 
-    public void ToggleAutoMode() => SetAutoMode(!_isAutoMode);
+    public void ToggleAutoMode() => SetAutoMode(!_engine.Auto);
 
     public void RequestSkip() => _onSkipRequested.OnNext(Unit.Default);
 
@@ -58,13 +64,13 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     public void Advance()
     {
         // オート中の送り入力はオートを解除する（意図しない自動進行を止める）
-        if (_isAutoMode && _progress.IsWaitingForNext)
+        if (_engine.Auto)
         {
             SetAutoMode(false);
             return;
         }
 
-        _progress.AdvanceToNext();
+        _engine.RequestAdvance();
     }
 
     /// <summary>
@@ -72,9 +78,8 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
     /// </summary>
     public void BeginSkip()
     {
-        _isSkipMode = true;
         SetAutoMode(false);
-        _progress.ForceComplete();
+        _engine.Skip = true;
     }
 
     public async UniTask ShowMessageAsync(NovelLine line, CancellationToken ct)
@@ -83,43 +88,41 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         nameLabel.text = line.DisplayName ?? "";
         HideNextIndicator();
 
-        var message = NovelDisplayText.Build(NovelTagLexer.Parse(line.Text));
+        var tokens = NovelTagLexer.Parse(line.Text);
+        _engine.Build(tokens);
 
-        if (_isSkipMode)
-        {
-            // 全文を即座に出し、待たずに次へ（1フレームだけ送って表示を反映させる）
-            messageLabel.text = message;
-            messageLabel.maxVisibleCharacters = int.MaxValue;
-            await UniTask.NextFrame(ct);
-            return;
-        }
+        messageLabel.text = NovelDisplayText.Build(tokens);
+        messageLabel.ForceMeshUpdate();
+        var tmpTotal = messageLabel.textInfo.characterCount;
+        messageLabel.maxVisibleCharacters = 0;
 
-        var typingToken = _progress.BeginTyping();
-
-        SeManager.Instance.PlaySeLoop(typingSeName, cancellationToken: _progress.DialogSeToken).Forget();
+        using var animCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var anim = AnimateEffectsAsync(animCts.Token).SuppressCancellationThrow();
+        var seCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        SeManager.Instance.PlaySeLoop(typingSeName, cancellationToken: seCts.Token).Forget();
 
         try
         {
-            await messageLabel.RichTextTypewriterAnimation(message, charSpeed, typingToken);
+            await _engine.RevealOnlyAsync(line.IsAlreadyRead,
+                v => messageLabel.maxVisibleCharacters = Mathf.Min(v, tmpTotal), ct);
         }
-        catch (OperationCanceledException)
+        finally
         {
-            // 文字送り中の送り入力でキャンセルされた場合は全文を即座に表示
-            messageLabel.maxVisibleCharacters = int.MaxValue;
+            // 打鍵音は送り待ちに入る前に止める
+            seCts.Cancel();
+            seCts.Dispose();
+            animCts.Cancel();
         }
-
-        // SEループもここで停止する
-        _progress.CompleteTyping();
 
         ShowNextIndicator();
-        await WaitForAdvanceAsync();
+        await _engine.WaitForAdvanceAsync(line.IsAlreadyRead, ct);
         HideNextIndicator();
     }
 
     public async UniTask<int> ShowChoicesAsync(IReadOnlyList<string> options, CancellationToken ct)
     {
         // 選択肢はプレイヤーの判断が要るのでスキップを打ち切る
-        _isSkipMode = false;
+        _engine.Skip = false;
 
         var tcs = new UniTaskCompletionSource<int>();
         var spawned = new List<GameObject>(options.Count);
@@ -151,14 +154,47 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
         messageLabel.text = "";
     }
 
-    // オート中は一定時間で自動送り。待機中に解除されたら手動待ちへ落とす
-    private async UniTask WaitForAdvanceAsync()
+    // shake/wave の頂点アニメ。区間はエンジンが可視index単位で算出済み
+    private async UniTask AnimateEffectsAsync(CancellationToken ct)
     {
-        // オート切替は待機をキャンセルして戻ってくるだけなので、進行が確定するまで待ち方を選び直す
-        while (_progress.IsWaitingForNext)
+        var shake = _engine.ShakeSpans;
+        var wave = _engine.WaveSpans;
+        if (shake.Count == 0 && wave.Count == 0) return;
+
+        while (!ct.IsCancellationRequested)
         {
-            if (_isAutoMode) await _progress.WaitForNextWithTimeout(autoNextDelay);
-            else await _progress.WaitForNext();
+            messageLabel.ForceMeshUpdate();
+            var info = messageLabel.textInfo;
+            var visible = messageLabel.maxVisibleCharacters;
+
+            ApplyOffset(info, shake, visible, isWave: false);
+            ApplyOffset(info, wave, visible, isWave: true);
+
+            for (var m = 0; m < info.meshInfo.Length; m++)
+                messageLabel.UpdateGeometry(info.meshInfo[m].mesh, m);
+
+            await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, ct);
+        }
+    }
+
+    private void ApplyOffset(TMP_TextInfo info, IReadOnlyList<(int start, int end)> ranges, int visible, bool isWave)
+    {
+        foreach (var (start, end) in ranges)
+        {
+            for (var i = start; i < end && i < visible && i < info.characterCount; i++)
+            {
+                var ch = info.characterInfo[i];
+                if (!ch.isVisible) continue;
+
+                var offset = isWave
+                    ? new Vector3(0f, Mathf.Sin(Time.time * waveSpeed + i * 0.5f) * waveAmplitude, 0f)
+                    : new Vector3(UnityEngine.Random.Range(-shakeAmplitude, shakeAmplitude),
+                        UnityEngine.Random.Range(-shakeAmplitude, shakeAmplitude), 0f);
+
+                var verts = info.meshInfo[ch.materialReferenceIndex].vertices;
+                var vi = ch.vertexIndex;
+                for (var k = 0; k < 4; k++) verts[vi + k] += offset;
+            }
         }
     }
 
@@ -214,17 +250,13 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
 
     private void SetAutoMode(bool on)
     {
-        if (_isAutoMode == on) return;
-
-        _isAutoMode = on;
-        autoButtonText.color = _isAutoMode ? autoButtonActiveColor : autoButtonNormalColor;
-
-        // 待機中の切り替えは進行中のタイムアウトを取り消して待ち方を組み直す
-        if (_progress.IsWaitingForNext) _progress.CancelWait();
+        _engine.Auto = on;
+        autoButtonText.color = on ? autoButtonActiveColor : autoButtonNormalColor;
     }
 
     private void Awake()
     {
+        _engine = new TextRevealEngine(this, new UnityFrameClock());
         autoButton.onClick.AddListener(ToggleAutoMode);
         skipButton.onClick.AddListener(RequestSkip);
         autoButtonText.color = autoButtonNormalColor;
@@ -232,7 +264,7 @@ public class NovelKitMessageView : MonoBehaviour, INovelView
 
     private void OnDestroy()
     {
+        _indicatorMotion.TryCancel();
         _onSkipRequested.Dispose();
-        _progress.Dispose();
     }
 }

--- a/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
@@ -8,10 +8,10 @@ using UnityEngine;
 using Void2610.UnityTemplate;
 
 /// <summary>
-/// novel-kit のIPortraitView実装
+/// novel-kit のIPortraitChannel実装
 /// レイアウト別のスロット座標へ立ち絵を配置し、表示・退場を行う
 /// </summary>
-public class NovelKitPortraitView : MonoBehaviour, IPortraitView
+public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel
 {
     [Serializable]
     private struct Slot
@@ -40,14 +40,14 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitView
         return UniTask.CompletedTask;
     }
 
-    public async UniTask ShowAsync(int slotIndex, string character, ResolvedSprite portrait, CancellationToken ct)
+    public async UniTask ShowAsync(int slotIndex, ResolvedSprite portrait, CancellationToken ct)
     {
         if (!IsValidSlot(slotIndex)) return;
         if (!portrait.IsLoaded)
         {
             // 消去指示 (空キー) は退場として扱い、ロード失敗だけ警告する
             if (portrait.IsCleared) await HideAsync(slotIndex, ct);
-            else Debug.LogWarning($"[NovelKitPortraitView] 立ち絵の解決に失敗: {character} ({portrait.Key})");
+            else Debug.LogWarning($"[NovelKitPortraitView] 立ち絵の解決に失敗: {portrait.Key}");
             return;
         }
 

--- a/Assets/Scripts/UI/Views/TextProgressController.cs
+++ b/Assets/Scripts/UI/Views/TextProgressController.cs
@@ -12,22 +12,11 @@ public class TextProgressController
     /// </summary>
     public CancellationToken DialogSeToken => _dialogSeCancellationTokenSource?.Token ?? CancellationToken.None;
 
-    /// <summary>
-    /// 送り待ち中かどうか
-    /// </summary>
-    public bool IsWaitingForNext => _isWaitingForNext;
-
     private CancellationTokenSource _typingCancellationTokenSource;
     private CancellationTokenSource _dialogSeCancellationTokenSource;
     private CancellationTokenSource _waitCancellationTokenSource;
     private bool _isTyping;
     private bool _isWaitingForNext;
-
-    /// <summary>
-    /// 待機だけを打ち切る（進行はさせない）
-    /// オート解除時に自動進行のタイムアウトを取り消し、手動待ちへ落とすために使う
-    /// </summary>
-    public void CancelWait() => _waitCancellationTokenSource?.Cancel();
 
     /// <summary>
     /// タイピングを開始し、キャンセルトークンを返す
@@ -133,17 +122,6 @@ public class TextProgressController
         _waitCancellationTokenSource?.Cancel();
 
         // 次へ進む
-        _isWaitingForNext = false;
-    }
-
-    /// <summary>
-    /// 文字送りも待機も打ち切って完了扱いにする（スキップ用）
-    /// </summary>
-    public void ForceComplete()
-    {
-        SkipTyping();
-
-        _waitCancellationTokenSource?.Cancel();
         _isWaitingForNext = false;
     }
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -22,7 +22,7 @@
     "com.unity.visualeffectgraph": "17.3.0",
     "com.unity.visualscripting": "1.9.9",
     "com.unityroom.client": "https://github.com/naichilab/unityroom-client-library.git?path=Assets/unityroom",
-    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#1dd19601caf55cc07f543e44fce7e69354ceaf54",
+    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#0f7da75ddfd6f1e04d49482c8aaa2412a44da52a",
     "com.void2610.unity-template": "https://github.com/void2610/my-unity-template.git",
     "com.yujiap.unity-toolbar-extension": "https://github.com/void2610/UnityToolbarExtension.git",
     "io.github.hatayama.uloopmcp": "https://github.com/hatayama/uLoopMCP.git?path=/Packages/src",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -450,13 +450,13 @@
       "hash": "c4dea57e1c27567bac512e090a356b08abf83d0b"
     },
     "com.void2610.novel-kit": {
-      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#1dd19601caf55cc07f543e44fce7e69354ceaf54",
+      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#0f7da75ddfd6f1e04d49482c8aaa2412a44da52a",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.ugui": "2.0.0"
       },
-      "hash": "1dd19601caf55cc07f543e44fce7e69354ceaf54"
+      "hash": "0f7da75ddfd6f1e04d49482c8aaa2412a44da52a"
     },
     "com.void2610.unity-template": {
       "version": "https://github.com/void2610/my-unity-template.git",


### PR DESCRIPTION
## 概要

文字送りの管理が novel-kit / void-red / my-unity-utils の 3 箇所にあり、ノベル経路が重複していたため。

> stacked PR: base は #212

## 変更点

- `NovelKitMessageView` を novel-kit の `TextRevealEngine` ベースにした。自前実装時に落ちていた `<w>` / `<p>` の待機、`<shake>` / `<wave>` の演出、既読判定つき skip が戻る
- `TextProgressController` からノベル用に足していた 3 メソッドを削除し、元の状態に戻した (残る利用は Narration / Tutorial のみ)
- novel-kit を最新 main に更新し、`IPortraitChannel` / `IBackgroundChannel` + `IStillChannel` への改名と `ShowAsync` の引数変更に追従した

打鍵音を打ち終わりで止めるために novel-kit 側で `RevealOnlyAsync` を分離している (void2610/novel-kit#24)。同 PR で「待機中に auto を入れると即進行する」不具合も直した。

## 動作確認

- [x] 打鍵音が打鍵中のみ鳴る
- [x] インジケーター・タグ非露出・立ち絵・背景が正常
- [x] オート ON → 3.20 秒後に進行 / OFF → 8 秒放置で進まない
- [x] スキップが選択肢で停止する