### PR TITLE
fix: ノベルのSEが互いに打ち切り合うのをやめる

### DIFF
--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -1062,7 +1062,6 @@ RectTransform:
   - {fileID: 9100021}
   - {fileID: 617654765780270993}
   - {fileID: 4554064236941310087}
-  - {fileID: 9149412424436397180}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1082,7 +1081,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 09b24bd844c34050badec050a89104b8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NovelKitAudioChannel
-  seManager: {fileID: 599100507661183887}
+  seManager: {fileID: 0}
 --- !u!114 &6903809405870213346
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1106,8 +1105,15 @@ MonoBehaviour:
   skipButton: {fileID: 8106790999200380143}
   autoButtonNormalColor: {r: 1, g: 1, b: 1, a: 1}
   autoButtonActiveColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
-  charSpeed: 0.03
-  autoNextDelay: 3
+  charsPerSecond: 33
+  autoAdvanceDelay: 3
+  skipUnread: 1
+  shakeAmplitude: 3
+  waveAmplitude: 4
+  waveSpeed: 6
+  indicatorBounceDuration: 1
+  indicatorBounceAmplitude: 5
+  indicatorOffset: {x: 30, y: 5}
   typingSeName: Dialog2
 --- !u!1 &9150722108618635631
 GameObject:
@@ -1427,77 +1433,4 @@ MonoBehaviour:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1548068314681488621, guid: 0c2403e33def945da82bf5ecf94a5001, type: 3}
   m_PrefabInstance: {fileID: 6292843370565394360}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8512021992826896100
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 7376430804190998633}
-    m_Modifications:
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832695855774412043, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-      propertyPath: m_Name
-      value: NovelSeManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
---- !u!114 &599100507661183887 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 9110967157870876011, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-  m_PrefabInstance: {fileID: 8512021992826896100}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a0089e532b114d4f817f50b04aa9c354, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &9149412424436397180 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 637814569318861464, guid: 80f1b94bb9bba4e2bb4926cf101b2891, type: 3}
-  m_PrefabInstance: {fileID: 8512021992826896100}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Root/SEManager.prefab
+++ b/Assets/Prefabs/Root/SEManager.prefab
@@ -208,4 +208,19 @@ MonoBehaviour:
   - name: SE_MEMORY_CARD_OPEN
     audioClip: {fileID: 8300000, guid: 33f6e0e7b697e48918cfdac3f0b3d09b, type: 3}
     volume: 1
+  - name: DoorArrival
+    audioClip: {fileID: 8300000, guid: c93930eed5f38433d927959acaa8eaec, type: 3}
+    volume: 1
+  - name: DoorArrivalBell
+    audioClip: {fileID: 8300000, guid: 4f9b3aca294014c29b23ca59266ba334, type: 3}
+    volume: 1
+  - name: Footstep
+    audioClip: {fileID: 8300000, guid: 6fca10ddade3146e59837bcf39a2b7c9, type: 3}
+    volume: 1
+  - name: ItemGet
+    audioClip: {fileID: 8300000, guid: e99e940c75bc441ad9e865c216eae354, type: 3}
+    volume: 1
+  - name: Item2
+    audioClip: {fileID: 8300000, guid: 33f6e0e7b697e48918cfdac3f0b3d09b, type: 3}
+    volume: 1
   maxChannels: 20

--- a/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
+++ b/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
@@ -3,15 +3,14 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using Novel.Runtime;
 using UnityEngine;
+using Void2610.UnityTemplate;
 
 /// <summary>
 /// novel-kit のIAudioChannel実装
-/// 既存のNovelSeManagerへSE再生を委譲する (BGMはノベル側で扱わないため未対応)
+/// SEはAudioSourceをプールしている共通のSeManagerへ委譲する (BGMはノベル側で扱わないため未対応)
 /// </summary>
 public class NovelKitAudioChannel : MonoBehaviour, IAudioChannel
 {
-    [SerializeField] private NovelSeManager seManager;
-
     private bool _bgmWarned;
 
     public void StopBgm() => WarnBgmUnsupported();
@@ -22,7 +21,7 @@ public class NovelKitAudioChannel : MonoBehaviour, IAudioChannel
     {
         if (ct.IsCancellationRequested) return UniTask.FromCanceled(ct);
 
-        seManager.PlaySe(seKey);
+        SeManager.Instance.PlaySe(seKey);
         return UniTask.CompletedTask;
     }
 
@@ -31,7 +30,7 @@ public class NovelKitAudioChannel : MonoBehaviour, IAudioChannel
         for (var i = 0; i < count; i++)
         {
             ct.ThrowIfCancellationRequested();
-            seManager.PlaySe(seKey);
+            SeManager.Instance.PlaySe(seKey);
             if (i < count - 1) await UniTask.Delay(TimeSpan.FromSeconds(interval), cancellationToken: ct);
         }
     }

--- a/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
+++ b/Assets/Scripts/NovelKit/NovelKitAudioChannel.cs
@@ -27,10 +27,11 @@ public class NovelKitAudioChannel : MonoBehaviour, IAudioChannel
 
     public async UniTask PlaySeLoopAsync(string seKey, float interval, int count, CancellationToken ct)
     {
+        var seManager = SeManager.Instance;
         for (var i = 0; i < count; i++)
         {
             ct.ThrowIfCancellationRequested();
-            SeManager.Instance.PlaySe(seKey);
+            seManager.PlaySe(seKey);
             if (i < count - 1) await UniTask.Delay(TimeSpan.FromSeconds(interval), cancellationToken: ct);
         }
     }

--- a/Docs/novel-scenario-migration.md
+++ b/Docs/novel-scenario-migration.md
@@ -22,10 +22,12 @@
 | `CharacterImageName` | `portrait` | 値 `Alv/Mask` → `Character/Alv/Mask.png` |
 | `BackgroundImageName` | `bg` | 値 `LobbyDark` → `Background/LobbyDark.jpg`。拡張子は資産ごとに png / jpg が混在する |
 | `SEClipName` | `se` | |
-| `CustomCharSpeed` | 未対応 | |
-| `AutoAdvance` | 未対応 | |
-| `GetItem` | 未対応 | prologue1 に 1 箇所。TODO コメントで位置のみ保持 |
-| `CardChoice` | 未対応 | prologue2 に 1 箇所。札画像なしの素の `choose` で代替 |
+| `CustomCharSpeed` | `<speed=N>` | どちらも速度の倍率。`<speed=0.25>` で 4 倍遅くなることを実測で確認 |
+| `AutoAdvance` | `<w=秒>` | オート専用の待ち時間は無い。行末に置けば手動・オートどちらでも同じだけ待つ |
+| `GetItem` | なし | prologue1 に 1 箇所。TODO コメントで位置のみ保持 |
+| `CardChoice` | なし | prologue2 に 1 箇所。札画像なしの素の `choose` で代替 |
+
+`CustomCharSpeed` / `AutoAdvance` は移行対象の 5 本では 1 件も使われておらず (旧 `test` シートのみ)、置き換え先が既存タグで足りるため新しいコマンドは足していない。
 
 `CharacterImageName` は「話者」ではなく「画面に出ている立ち絵」を指す。主人公のセリフ行にも相手の立ち絵が指定されるため、`say` の第 3 引数ではなく `portrait` で切り替える。
 


### PR DESCRIPTION
## 概要

ノベルの SE が AudioSource 1 本を使い回しており、後の SE が前の SE を必ず打ち切っていたため。エレベーターの音が扉の音で途切れる症状として現れていた。

## 変更点

- SE の再生先を、AudioSource をプールしている共通の `SeManager` に切り替えた
- ノベル専用だった 5 件 (`DoorArrival` / `DoorArrivalBell` / `Footstep` / `ItemGet` / `Item2`) を共通側へ登録し、`NovelSeManager` の実体をプレハブから外した
- 旧 Excel の `CustomCharSpeed` / `AutoAdvance` の置き換え先を移行メモに追記した。どちらも既存のインラインタグ (`<speed=N>` / `<w=秒>`) で足りるため、新しいコマンドは足していない

`NovelSeManager` のクラス自体は旧 `NovelPresenter` がまだ参照しているため残している (旧実装の削除時に一緒に消す)。

### プレハブ差分に SE 以外の項目が含まれている理由

`NovelKitView.prefab` の差分に `charsPerSecond` / `wave*` / `indicator*` 等が現れるが、これは本 PR で値を変えたものではない。

#213 で `NovelKitMessageView` の SerializeField を改名 (`charSpeed` → `charsPerSecond`、`autoNextDelay` → `autoAdvanceDelay`) した際、プレハブ側を再シリアライズしていなかったため、main のプレハブには旧キーが残ったままだった。本 PR で `NovelSeManager` を外すためにプレハブを保存した結果、Unity が新しいキーで書き直している。

旧 `charSpeed: 0.03` は 1 文字あたりの秒数で、新 `charsPerSecond: 33` と同じ速度。`autoNextDelay: 3` も `autoAdvanceDelay: 3` と同値のため、挙動は変わらない (これまでは新キーが無く C# の既定値にフォールバックしていた)。

## 動作確認

- [x] 同フレームで 2 つの SE を鳴らし、2 本が同時に鳴ることを確認 (修正前は必ず 1 本に潰れていた)
- [x] 打鍵音・シナリオ SE・送り待ち表示が通しで正常
- [x] `<speed=0.25>` で文字送りが 3.20 秒 (既定約 0.8 秒) になることを実測
