### PR TITLE
feat: 立ち絵の構図をエディタから確認・編集できるようにする

### DIFF
--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -147,11 +147,11 @@ MonoBehaviour:
   layouts:
   - layoutId: single
     slotPositions:
-    - {x: 0, y: -80}
+    - {x: 0, y: -345}
   - layoutId: pair
     slotPositions:
-    - {x: -450, y: -80}
-    - {x: 450, y: -80}
+    - {x: -450, y: -345}
+    - {x: 450, y: -345}
   fadeDuration: 0.5
 --- !u!1 &9100030
 GameObject:
@@ -189,8 +189,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 900, y: 1150}
+  m_AnchoredPosition: {x: -450, y: -345}
+  m_SizeDelta: {x: 900, y: 1400}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!225 &9100033
 CanvasGroup:
@@ -277,7 +277,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -352,7 +352,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -405,8 +405,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 900, y: 1150}
+  m_AnchoredPosition: {x: 450, y: -345}
+  m_SizeDelta: {x: 900, y: 1400}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!225 &9100053
 CanvasGroup:
@@ -493,7 +493,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -568,7 +568,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
@@ -34,7 +34,7 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel, IStageLayou
 
     private readonly HashSet<int> _visibleSlots = new();
 
-    public IEnumerable<StageLayoutInfo> EnumerateLayouts() => layouts.Select(e => new StageLayoutInfo(e.layoutId, e.slotPositions.Length));
+    public IEnumerable<StageLayoutInfo> EnumerateLayouts() => layouts.Select(e => new StageLayoutInfo(e.layoutId, e.slotPositions?.Length ?? 0));
 
     public IReadOnlyList<Vector2> GetLayoutPositions(string layoutId) => layouts.FirstOrDefault(e => e.layoutId == layoutId).slotPositions ?? Array.Empty<Vector2>();
 

--- a/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using LitMotion;
@@ -11,7 +12,7 @@ using Void2610.UnityTemplate;
 /// novel-kit のIPortraitChannel実装
 /// レイアウト別のスロット座標へ立ち絵を配置し、表示・退場を行う
 /// </summary>
-public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel
+public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel, IStageLayoutEditor
 {
     [Serializable]
     private struct Slot
@@ -33,6 +34,23 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel
 
     private readonly HashSet<int> _visibleSlots = new();
 
+    public IEnumerable<StageLayoutInfo> EnumerateLayouts() => layouts.Select(e => new StageLayoutInfo(e.layoutId, e.slotPositions.Length));
+
+    public IReadOnlyList<Vector2> GetLayoutPositions(string layoutId) => layouts.FirstOrDefault(e => e.layoutId == layoutId).slotPositions ?? Array.Empty<Vector2>();
+
+    public IReadOnlyList<Vector2> GetCurrentSlotPositions() => slots.Select(s => ((RectTransform)s.group.transform).anchoredPosition).ToArray();
+
+    public void SetLayoutPositions(string layoutId, IReadOnlyList<Vector2> positions)
+    {
+        for (var i = 0; i < layouts.Length; i++)
+        {
+            if (layouts[i].layoutId != layoutId) continue;
+
+            layouts[i].slotPositions = positions.ToArray();
+            return;
+        }
+    }
+
     // 座標を書き換えるだけなので待機は発生しない
     public UniTask SwitchLayoutAsync(PortraitLayout layout, CancellationToken ct)
     {
@@ -52,6 +70,15 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel
         }
 
         var slot = slots[slotIndex];
+        if (!Application.isPlaying)
+        {
+            // 編集モードではモーションが進まないので、待たずに最終状態へ飛ばす
+            slot.image.SetImmediate(portrait.Sprite);
+            slot.group.alpha = 1f;
+            _visibleSlots.Add(slotIndex);
+            return;
+        }
+
         await slot.image.CrossfadeAsync(portrait.Sprite, ct);
         if (_visibleSlots.Add(slotIndex))
             await slot.group.FadeIn(fadeDuration).ToUniTask(cancellationToken: ct);
@@ -60,6 +87,12 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel
     public async UniTask HideAsync(int slotIndex, CancellationToken ct)
     {
         if (!_visibleSlots.Remove(slotIndex)) return;
+
+        if (!Application.isPlaying)
+        {
+            slots[slotIndex].group.alpha = 0f;
+            return;
+        }
 
         await slots[slotIndex].group.FadeOut(fadeDuration).ToUniTask(cancellationToken: ct);
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -22,7 +22,7 @@
     "com.unity.visualeffectgraph": "17.3.0",
     "com.unity.visualscripting": "1.9.9",
     "com.unityroom.client": "https://github.com/naichilab/unityroom-client-library.git?path=Assets/unityroom",
-    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#e4a39547ce3238b6780f451028b2bd75810ee815",
+    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#38dafc31dcb2845b9119a0b5a738f589cbde3f36",
     "com.void2610.unity-template": "https://github.com/void2610/my-unity-template.git",
     "com.yujiap.unity-toolbar-extension": "https://github.com/void2610/UnityToolbarExtension.git",
     "io.github.hatayama.uloopmcp": "https://github.com/hatayama/uLoopMCP.git?path=/Packages/src",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -450,13 +450,13 @@
       "hash": "c4dea57e1c27567bac512e090a356b08abf83d0b"
     },
     "com.void2610.novel-kit": {
-      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#e4a39547ce3238b6780f451028b2bd75810ee815",
+      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#38dafc31dcb2845b9119a0b5a738f589cbde3f36",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.ugui": "2.0.0"
       },
-      "hash": "e4a39547ce3238b6780f451028b2bd75810ee815"
+      "hash": "38dafc31dcb2845b9119a0b5a738f589cbde3f36"
     },
     "com.void2610.unity-template": {
       "version": "https://github.com/void2610/my-unity-template.git",


### PR DESCRIPTION
## 概要

立ち絵の slot 座標は再生して初めて適用されるため、調整のたびに Play を往復していたため。

## 変更点

- novel-kit を更新し、`Novel/Stage Preview` を使えるようにした (void2610/novel-kit#41)
- `NovelKitPortraitView` が窓の契約に対応
  - 非再生時はアニメーションを待たず即座に反映する (編集モードでは PlayerLoop が回らず、待つと完了しない)
  - `EnumerateLayouts()` が実際に定義した構図だけを返す (既定のままだと実在しない trio/quad/penta が並んでいた)
  - `IStageLayoutEditor` を実装し、窓から座標の編集と取り込みができる
- 上記の窓で立ち絵の位置と大きさを調整した

## 動作確認

- [x] 非再生のまま構図と実物の立ち絵がシーンに並ぶ
- [x] 窓で座標を変えると即座に反映され、構図に保存される
- [x] シーンで動かした位置を構図へ取り込める
- [x] 再生時に開始直後の立ち絵の残留がなく、調整後の座標で表示される