### PR TITLE
fix: プレビューの片付けで白い矩形が残らないようにする

### DIFF
--- a/Assets/Prefabs/Novel/NovelKitView.prefab
+++ b/Assets/Prefabs/Novel/NovelKitView.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -493,7 +493,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
+++ b/Assets/Scripts/NovelKit/NovelKitPortraitView.cs
@@ -86,13 +86,18 @@ public class NovelKitPortraitView : MonoBehaviour, IPortraitChannel, IStageLayou
 
     public async UniTask HideAsync(int slotIndex, CancellationToken ct)
     {
-        if (!_visibleSlots.Remove(slotIndex)) return;
+        if (!IsValidSlot(slotIndex)) return;
 
         if (!Application.isPlaying)
         {
+            // プレビューの片付け。参照を残すとプレハブがその立ち絵を抱え込むのでスプライトごと外す
+            _visibleSlots.Remove(slotIndex);
+            slots[slotIndex].image.Clear();
             slots[slotIndex].group.alpha = 0f;
             return;
         }
+
+        if (!_visibleSlots.Remove(slotIndex)) return;
 
         await slots[slotIndex].group.FadeOut(fadeDuration).ToUniTask(cancellationToken: ct);
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -22,7 +22,7 @@
     "com.unity.visualeffectgraph": "17.3.0",
     "com.unity.visualscripting": "1.9.9",
     "com.unityroom.client": "https://github.com/naichilab/unityroom-client-library.git?path=Assets/unityroom",
-    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#38dafc31dcb2845b9119a0b5a738f589cbde3f36",
+    "com.void2610.novel-kit": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#bf7e35f1ab48f95fa96870baae85dacac8be8347",
     "com.void2610.unity-template": "https://github.com/void2610/my-unity-template.git",
     "com.yujiap.unity-toolbar-extension": "https://github.com/void2610/UnityToolbarExtension.git",
     "io.github.hatayama.uloopmcp": "https://github.com/hatayama/uLoopMCP.git?path=/Packages/src",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -450,13 +450,13 @@
       "hash": "c4dea57e1c27567bac512e090a356b08abf83d0b"
     },
     "com.void2610.novel-kit": {
-      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#38dafc31dcb2845b9119a0b5a738f589cbde3f36",
+      "version": "https://github.com/void2610/novel-kit.git?path=Assets/Novel#bf7e35f1ab48f95fa96870baae85dacac8be8347",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.ugui": "2.0.0"
       },
-      "hash": "38dafc31dcb2845b9119a0b5a738f589cbde3f36"
+      "hash": "bf7e35f1ab48f95fa96870baae85dacac8be8347"
     },
     "com.void2610.unity-template": {
       "version": "https://github.com/void2610/my-unity-template.git",


### PR DESCRIPTION
## 概要

構図プレビューを片付けたあと、立ち絵の裏面が白い矩形として残っていた。UI の Image はスプライトが無く不透明だと白く描画されるため。

## 変更点

- 片付けを `CrossfadeImage.Clear()` に変更 (両面のスプライトを外し alpha も落とす)。従来の `SetImmediate(null)` は裏面を不透明のまま残していた
- プレハブに保存されてしまっていた白矩形の状態を除去
- utils と novel-kit を最新にした
  - `CrossfadeImage.Clear()` (void2610/my-unity-utils#13)
  - 適用時にスプライト未指定の slot を隠す (void2610/novel-kit#42)

## 動作確認

「スプライト無しで不透明」な Image の数を数えて確認した。

- [x] プレハブ初期・2枚適用後・1枚だけ適用後・クリア後、いずれも白矩形なし
- [x] slot 1 を未指定にして再適用すると、前回の絵が残らない
- [x] 再生中も白矩形が出ず、立ち絵が正常に表示される