### PR TITLE
fix: 立ち絵が既定の顔に戻ってしまうのをやめる

### DIFF
--- a/Assets/ScriptableObjects/NovelKit/CharacterCatalog.asset
+++ b/Assets/ScriptableObjects/NovelKit/CharacterCatalog.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
     defaultPortraitKey:
   - speakerId: cerica
     displayName: "\u30BB\u30EA\u30AB"
-    defaultPortraitKey: Character/Cerica/Normal.png
+    defaultPortraitKey:
   - speakerId: alv
     displayName: "\u30A2\u30EB\u30F4"
-    defaultPortraitKey: Character/Alv/Normal.png
+    defaultPortraitKey:


### PR DESCRIPTION
## 概要

アルヴの初登場で仮面の立ち絵がフェードインした直後、素顔に差し替わっていた。

novel-kit の `ResolvePortraitKey` は `say` に `portrait` の指定が無いとカタログの既定立ち絵を無条件に適用する。今出ている立ち絵を見ないため、直前の `portrait` コマンドが毎行上書きされていた。

## 変更点

- カタログから `defaultPortraitKey` を外した

全シナリオが `stage` の直後に `portrait` を明示しており (`prologue1` / `prologue2` / `cerica1` / `cerica2` / `test`)、既定立ち絵に依存する箇所は無い。

## 動作確認

表示中のスプライトが変わるたびに記録して確認した。

- [x] `prologue1`: `Mask` のみ (修正前は `Mask → Normal`)
- [x] `cerica1`: `Normal → Sad → Normal → Smile → Normal → Sad → Normal → Smile` とシナリオの `portrait` 指定に一致